### PR TITLE
Add salt master dns record.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,18 @@ And when you run the tool you must set the ARN ID of the role in the separate ac
 
     AWS_ROLE_ARN_ID='arn:aws:iam::123456789012:role/S3Access' fab application:courtfinder aws:prod environment:dev config:/path/to/courtfinder-dev.yaml salt.setup
 
+Salt master DNS
+++++++++++++++++
+This tool will attempt to create a DNS entry for the salt master during the bootstrap process. You must specify the zone in which to create the entry in the bootstrap-cfn config file like so::
+
+    master_zone: myzone.dsd.io
+
+If you do not specify a zone, then no entry will be created and you will need AWS credentials as above to discover the master when deploying etc.
+
+The entry created will be::
+
+    master.<environment>.<application>.<master_zone>
+
 Salt specific configuration
 ++++++++++++++++++++++++++++
 

--- a/bootstrap_salt/r53.py
+++ b/bootstrap_salt/r53.py
@@ -1,0 +1,35 @@
+import boto.route53
+import utils
+
+
+class R53:
+
+    conn_cfn = None
+    aws_region_name = None
+    aws_profile_name = None
+
+    def __init__(self, aws_profile_name, aws_region_name='eu-west-1'):
+        self.aws_profile_name = aws_profile_name
+        self.aws_region_name = aws_region_name
+
+        self.conn_r53 = utils.connect_to_aws(boto.route53, self)
+
+    def get_hosted_zone_id(self, zone_name):
+        '''
+        Take a zone name
+        Return a zone id or None if no zone found
+        '''
+        zone = self.conn_r53.get_hosted_zone_by_name(zone_name)
+        if zone:
+            zone = zone['GetHostedZoneResponse']['HostedZone']['Id']
+            return zone.replace('/hostedzone/', '')
+
+    def update_dns_record(self, zone, record, record_type, record_value):
+        '''
+        Returns True if update successful or raises an exception if not
+        '''
+        changes = boto.route53.record.ResourceRecordSets(self.conn_r53, zone)
+        change = changes.add_change("UPSERT", record, record_type, ttl=60)
+        change.add_value(record_value)
+        changes.commit()
+        return True

--- a/tests/test.py
+++ b/tests/test.py
@@ -69,6 +69,7 @@ class BootstrapSaltTestCase(unittest.TestCase):
                                   'multi-az': False,
                                   'storage': 5,
                                   'storage-type': 'gp2'},
+                          'master_zone': 'blah.dsd.io',
                           's3': {'static-bucket-name': 'moj-test-dev-static'}}}
         yaml.dump(config, open(self.env.config, 'w'))
 

--- a/tests/test_r53.py
+++ b/tests/test_r53.py
@@ -1,0 +1,42 @@
+from bootstrap_salt import r53
+import unittest
+import tempfile
+import boto.route53
+import mock
+import os
+
+
+class BootstrapSaltR53TestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.work_dir = tempfile.mkdtemp()
+        self.env = mock.Mock()
+        self.env.aws = 'dev'
+        self.env.aws_profile = 'the-profile-name'
+        self.env.environment = 'dev'
+        self.env.application = 'unittest-app'
+        self.env.config = os.path.join(self.work_dir, 'test_config.yaml')
+
+    def test_update_dns_record(self):
+        r53_mock = mock.Mock()
+        r53_connect_result = mock.Mock(name='cf_connect')
+        r53_mock.return_value = r53_connect_result
+        boto.route53.connect_to_region = r53_mock
+        r = r53.R53(self.env.aws_profile)
+        x = r.update_dns_record('blah/blah', 'x.y', 'A', '1.1.1.1')
+        self.assertTrue(x)
+
+    def test_get_hosted_zone_id(self):
+        r53_mock = mock.Mock()
+        r53_connect_result = mock.Mock(name='cf_connect')
+        r53_mock.return_value = r53_connect_result
+        response = {'GetHostedZoneResponse': {}}
+        zone_response = {'HostedZone': {'Id': 'blah/blah'}}
+        response['GetHostedZoneResponse'] = zone_response
+
+        mock_config = {'get_hosted_zone_by_name.return_value': response}
+        r53_connect_result.configure_mock(**mock_config)
+        boto.route53.connect_to_region = r53_mock
+        r = r53.R53(self.env.aws_profile)
+        x = r.get_hosted_zone_id('blah')
+        self.assertEquals(x, 'blah/blah')


### PR DESCRIPTION
The idea here is to simplify the deployment process by not having to connect to the EC2 API to find the master's IP.

* Needs documentation (but I guess we need to refactor the README first...)
* I will open a PR against template-deploy to use the new DNS entry once this has been merged