### PR TITLE
Remove unused scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/_build/
 
 # PyBuilder
 target/
+.DS_Store

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -79,15 +79,22 @@ def install_minions():
     ec2.set_instance_tags(to_install, {'SaltMasterPrvIP': master_prv_ip})
     for inst_ip in public_ips:
         env.host_string = 'ubuntu@%s' % inst_ip
-        sudo('wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-salt/master/scripts/bootstrap-salt.sh -O /tmp/moj-bootstrap.sh')
-        sudo('chmod 755 /tmp/moj-bootstrap.sh')
-        sudo('/tmp/moj-bootstrap.sh')
+        # copy the salt_utils.py from local to EC2 and chmod it
+        d = os.path.dirname(__file__)
+        saltutils = d + "/salt_utils.py"
+        if not os.path.isfile(saltutils):
+            print "ERROR: Cannot find %s" % saltutils
+            sys.exit(1)
+        put(saltutils, '/tmp')
+        sudo('cp /tmp/salt_utils.py /usr/local/bin')
+        sudo('chmod 755 /usr/local/bin/salt_utils.py')
+        #
         sudo(
             'wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/%s/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh' %
             sha)
         sudo('chmod 755 /tmp/bootstrap-salt.sh')
         sudo(
-            '/tmp/bootstrap-salt.sh -A `cat /etc/tags/SaltMasterPrvIP` git v2014.1.4')
+            '/tmp/bootstrap-salt.sh -A ' + master_prv_ip + ' git v2014.1.4')
         env.host_string = 'ubuntu@%s' % master_public_ip
         sudo('salt-key -y -A')
 
@@ -113,16 +120,23 @@ def install_master():
     stack_public_ips.remove(master_public_ip)
     env.host_string = 'ubuntu@%s' % master_public_ip
     sha = '6080a18e6c7c2d49335978fa69fa63645b45bc2a'
-    sudo('wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-salt/master/scripts/bootstrap-salt.sh -O /tmp/moj-bootstrap.sh')
-    sudo('chmod 755 /tmp/moj-bootstrap.sh')
-    sudo('/tmp/moj-bootstrap.sh')
+    # copy the salt_utils.py from local to EC2 and chmod it
+    d = os.path.dirname(__file__)
+    saltutils = d + "/salt_utils.py"
+    if not os.path.isfile(saltutils):
+        print "ERROR: Cannot find %s" % saltutils
+        sys.exit(1)
+    put(saltutils, '/tmp')
+    sudo('cp /tmp/salt_utils.py /usr/local/bin')
+    sudo('chmod 755 /usr/local/bin/salt_utils.py')
+    #
     sudo(
         'wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/%s/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh' %
         sha)
     sudo('chmod 755 /tmp/bootstrap-salt.sh')
     sudo(
-        '/tmp/bootstrap-salt.sh -M -A `cat /etc/tags/SaltMasterPrvIP`\
-         git v2014.1.4')
+        '/tmp/bootstrap-salt.sh -M -A ' + master_prv_ip +
+        ' git v2014.1.4')
     sudo('salt-key -y -A')
 
 


### PR DESCRIPTION
Remove moj-bootstrap.sh and ec2_tags.py. The address of the salt master is already available within fab_tasks.py
Tested using a local copy of bootstrap-salt.