### PR TITLE
Validate the environment variables when calling rsync

### DIFF
--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -128,6 +128,7 @@ def install_master():
 
 @task
 def rsync():
+    _validate_fabric_env()
     work_dir = os.path.dirname(env.real_fabfile)
     project_config = config.ProjectConfig(env.config,
                                           env.environment,


### PR DESCRIPTION
salt.rsync fails when there's no env.stack_passwords, as it tries to
pass it to ProjectConfig. This change calls _validate_fabric_env()
before doing anything else, so all needed env variables are defined