### PR TITLE
[add_missing_fabric_tasks] Added some missing fabric tasks. Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# bootstrap-salt

--- a/README.rst
+++ b/README.rst
@@ -38,12 +38,12 @@ Bootstrap-salt uses `fabric <http://www.fabfile.org/>`_
 
 If you also want to bootstrap the salt master and minions, you can do this::
 
-    fab application:courtfinder aws:prod environment:dev config:/path/to/courtfinder-dev.yaml salt.setup
+    fab application:app-name aws:dev environment:dev config:/path/to/app-name-dev-config.yaml salt.setup
 
-- **application:courtfinder** - should match the name given to bootstrap-cfn
+- **application:app-name** - should match the name given to bootstrap-cfn
 - **aws:dev** - is a way to differentiate between AWS accounts ``(~/.config.yaml)``
 - **environment:dev** - should match the environment given to bootstrap-cfn
-- **config:/path/to/file.yaml** - The location to the project YAML file
+- **config:/path/to/app-name-dev-config.yaml** - The location to the project YAML file
 
 Example Configuration
 ======================

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -10,7 +10,7 @@ from fabric.api import env, task, sudo, put
 from fabric.contrib.project import upload_project
 from cloudformation import Cloudformation
 from ec2 import EC2
-import bootstrap_cfn.config as config
+import bootstrap_cfn.config as cfn_config
 from bootstrap_cfn.fab_tasks import _validate_fabric_env, get_stack_name
 
 # GLOBAL VARIABLES
@@ -29,6 +29,21 @@ env.stack = None
 @task
 def aws(x):
     env.aws = str(x).lower()
+
+
+@task
+def environment(x):
+    env.environment = str(x).lower()
+
+
+@task
+def application(x):
+    env.application = str(x).lower()
+
+
+@task
+def config(x):
+    env.config = str(x).lower()
 
 
 @task
@@ -130,9 +145,9 @@ def install_master():
 def rsync():
     _validate_fabric_env()
     work_dir = os.path.dirname(env.real_fabfile)
-    project_config = config.ProjectConfig(env.config,
-                                          env.environment,
-                                          env.stack_passwords)
+    project_config = cfn_config.ProjectConfig(env.config,
+                                              env.environment,
+                                              env.stack_passwords)
     cfg = project_config.config
 
     salt_cfg = cfg.get('salt', {})


### PR DESCRIPTION
* Removed README.md as README.rst actually contains all the relevant information
* Made some minor changes to README.rst to remove project-specific values in
  example locations.
* Some tasks were still defined in bootstrap_cfn but not in
  bootstrap_salt - but were necessary for successful operation. Added them.
* Renamed reference to config (a task) and the cloudformation config file,
  so that the command line works as expected.