### PR TITLE
Change to dedicated master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# bootstrap-salt

--- a/README.rst
+++ b/README.rst
@@ -38,12 +38,12 @@ Bootstrap-salt uses `fabric <http://www.fabfile.org/>`_
 
 If you also want to bootstrap the salt master and minions, you can do this::
 
-    fab application:courtfinder aws:prod environment:dev config:/path/to/courtfinder-dev.yaml salt.setup
+    fab application:app-name aws:dev environment:dev config:/path/to/app-name-dev-config.yaml salt.setup
 
-- **application:courtfinder** - should match the name given to bootstrap-cfn
+- **application:app-name** - should match the name given to bootstrap-cfn
 - **aws:dev** - is a way to differentiate between AWS accounts ``(~/.config.yaml)``
 - **environment:dev** - should match the environment given to bootstrap-cfn
-- **config:/path/to/file.yaml** - The location to the project YAML file
+- **config:/path/to/app-name-dev-config.yaml** - The location to the project YAML file
 
 Example Configuration
 ======================

--- a/bootstrap_salt/errors.py
+++ b/bootstrap_salt/errors.py
@@ -4,18 +4,22 @@ class BootstrapCfnError(Exception):
     def __init__(self, msg):
         print >> sys.stderr,  "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
 
+
 class CfnConfigError(BootstrapCfnError):
     pass
+
 
 class CfnTimeoutError(BootstrapCfnError):
     pass
 
+
 class NoCredentialsError(BootstrapCfnError):
     def __init__(self):
-        super(NoCredentialsErrror, self).__init__(
+        super(NoCredentialsError, self).__init__(
             "Create an ~/.aws/credentials file by following this layout:\n\n" +
             "  http://boto.readthedocs.org/en/latest/boto_config_tut.html#credentials"
         )
+
 
 class ProfileNotFoundError(BootstrapCfnError):
     def __init__(self, profile_name):
@@ -23,8 +27,14 @@ class ProfileNotFoundError(BootstrapCfnError):
             "'{0}' not found in ~/.aws/credentials".format(profile_name)
         )
 
+
 class SaltStateError(BootstrapCfnError):
     pass
 
+
 class SaltParserError(BootstrapCfnError):
+    pass
+
+
+class SaltNoMasterInstance(BootstrapCfnError):
     pass

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -10,7 +10,7 @@ from fabric.api import env, task, sudo, put
 from fabric.contrib.project import upload_project
 from cloudformation import Cloudformation
 from ec2 import EC2
-import bootstrap_cfn.config as config
+import bootstrap_cfn.config as cfn_config
 from bootstrap_cfn.fab_tasks import _validate_fabric_env, get_stack_name
 
 # GLOBAL VARIABLES
@@ -29,6 +29,21 @@ env.stack = None
 @task
 def aws(x):
     env.aws = str(x).lower()
+
+
+@task
+def environment(x):
+    env.environment = str(x).lower()
+
+
+@task
+def application(x):
+    env.application = str(x).lower()
+
+
+@task
+def config(x):
+    env.config = str(x).lower()
 
 
 @task
@@ -130,9 +145,9 @@ def install_master():
 def rsync():
     _validate_fabric_env()
     work_dir = os.path.dirname(env.real_fabfile)
-    project_config = config.ProjectConfig(env.config,
-                                          env.environment,
-                                          env.stack_passwords)
+    project_config = cfn_config.ProjectConfig(env.config,
+                                              env.environment,
+                                              env.stack_passwords)
     cfg = project_config.config
 
     salt_cfg = cfg.get('salt', {})

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -3,7 +3,6 @@
 import os
 from StringIO import StringIO
 import sys
-import random
 import yaml
 
 from fabric.api import env, task, sudo, put
@@ -25,6 +24,7 @@ sys.path.append(os.path.dirname(path))
 
 
 env.stack = None
+
 
 @task
 def aws(x):
@@ -57,20 +57,20 @@ def get_connection(klass):
     return klass(env.aws, env.aws_region)
 
 
+@task
 def find_master():
     _validate_fabric_env()
-    stack_name = get_stack_name()
     ec2 = get_connection(EC2)
-    master = ec2.get_master_instance(stack_name).ip_address
-    print 'Salt master public address: {0}'.format(master)
-    return master
+    master_ip = ec2.get_master_instance().ip_address
+    print 'Salt master public address: {0}'.format(master_ip)
+    return master_ip
 
 
 def get_candidate_minions(stack_name):
     cfn = get_connection(Cloudformation)
     ec2 = get_connection(EC2)
     instance_ids = cfn.get_stack_instance_ids(stack_name)
-    master_instance_id = ec2.get_master_instance(stack_name).id
+    master_instance_id = ec2.get_master_instance().id
     instance_ids.remove(master_instance_id)
     return instance_ids
 
@@ -88,7 +88,7 @@ def install_minions():
         return
     public_ips = ec2.get_instance_public_ips(to_install)
     sha = '6080a18e6c7c2d49335978fa69fa63645b45bc2a'
-    master_inst = ec2.get_master_instance(stack_name)
+    master_inst = ec2.get_master_instance()
     master_public_ip = master_inst.ip_address
     master_prv_ip = master_inst.private_ip_address
     ec2.set_instance_tags(to_install, {'SaltMasterPrvIP': master_prv_ip})
@@ -107,26 +107,20 @@ def install_minions():
         sudo('salt-key -y -A')
 
 
+@task
 def install_master():
     _validate_fabric_env()
-    stack_name = get_stack_name()
-    ec2 = get_connection(EC2)
-    cfn = get_connection(Cloudformation)
-    print "Waiting for SSH on all instances..."
-    ec2.wait_for_ssh(stack_name)
-    instance_ids = cfn.get_stack_instance_ids(stack_name)
-    master_inst = ec2.get_master_instance(stack_name)
-    master = master_inst.id if master_inst else random.choice(instance_ids)
-    master_prv_ip = ec2.get_instance_private_ips([master])[0]
-    master_public_ip = ec2.get_instance_public_ips([master])[0]
-    ec2.set_instance_tags(instance_ids, {'SaltMasterPrvIP': master_prv_ip})
-    ec2.set_instance_tags(master, {'SaltMaster': 'True'})
 
-    stack_ips = ec2.get_instance_private_ips(instance_ids)
-    stack_ips.remove(master_prv_ip)
-    stack_public_ips = ec2.get_instance_public_ips(instance_ids)
-    stack_public_ips.remove(master_public_ip)
-    env.host_string = 'ubuntu@%s' % master_public_ip
+    ec2 = get_connection(EC2)
+    master = ec2.get_master_instance()
+
+    print "Waiting for SSH on master..."
+    ec2.wait_for_ssh([master.id])
+    print "Ready"
+
+    ec2.set_instance_tags(master.id, {'SaltMaster': 'True'})
+
+    env.host_string = 'ubuntu@%s' % master.ip_address
     sha = '6080a18e6c7c2d49335978fa69fa63645b45bc2a'
     sudo('wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-salt/master/scripts/bootstrap-salt.sh -O /tmp/moj-bootstrap.sh')
     sudo('chmod 755 /tmp/moj-bootstrap.sh')
@@ -139,6 +133,20 @@ def install_master():
         '/tmp/bootstrap-salt.sh -M -A `cat /etc/tags/SaltMasterPrvIP`\
          git v2014.1.4')
     sudo('salt-key -y -A')
+
+
+@task
+def set_master_private_ip():
+    _validate_fabric_env()
+    stack_name = get_stack_name()
+
+    ec2 = get_connection(EC2)
+    cfn = get_connection(Cloudformation)
+
+    master = ec2.get_master_instance()
+    instance_ids = cfn.get_stack_instance_ids(stack_name)
+
+    ec2.set_instance_tags(instance_ids, {'SaltMasterPrvIP': master.ip_address})
 
 
 @task


### PR DESCRIPTION
( Note that this depends on https://github.com/ministryofjustice/bootstrap-salt/pull/10 )

To support autoscaling, we need to use a dedicated salt master, rather than randomly selecting an existing host.

- Cleaned up some flake8 errors
- Fixed typo of NoCredentialsErrror -> NoCredentialsError