### PR TITLE
Make find_master a task

### DIFF
--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -42,6 +42,7 @@ def get_connection(klass):
     return klass(env.aws, env.aws_region)
 
 
+@task
 def find_master():
     _validate_fabric_env()
     stack_name = get_stack_name()


### PR DESCRIPTION
Task decorator for find_master disappeared during the migration from bootstrap_cfn. Adding it back in.