### PR TITLE
Add missing bootstrap-cfn requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ boto==2.36.0
 mock==1.0.1
 testfixtures==4.1.2
 paramiko
+git+ssh://git@github.com/ministryofjustice/bootstrap-cfn.git@v0.3.0#egg=bootstrap-cfn>=0.3.0


### PR DESCRIPTION
If the goal is to be able to use bootstrap-salt on its own then we need bootstrap-cfn as it's used in:
https://github.com/ministryofjustice/bootstrap-salt/blob/master/bootstrap_salt/fab_tasks.py#L14

For the reviewer: If however we're not planning on using bootstrap-salt on its own then feel free to close this pull request.