### PR TITLE
Remove unused scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/_build/
 
 # PyBuilder
 target/
+.DS_Store

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -79,15 +79,22 @@ def install_minions():
     ec2.set_instance_tags(to_install, {'SaltMasterPrvIP': master_prv_ip})
     for inst_ip in public_ips:
         env.host_string = 'ubuntu@%s' % inst_ip
-        sudo('wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-salt/master/scripts/bootstrap-salt.sh -O /tmp/moj-bootstrap.sh')
-        sudo('chmod 755 /tmp/moj-bootstrap.sh')
-        sudo('/tmp/moj-bootstrap.sh')
+        # copy the salt_utils.py from local to EC2 and chmod it
+        d = os.path.dirname(__file__)
+        saltutils = d + "/salt_utils.py"
+        if not os.path.isfile(saltutils):
+            print "ERROR: Cannot find %s" % saltutils
+            sys.exit(1)
+        put(saltutils, '/tmp')
+        sudo('cp /tmp/salt_utils.py /usr/local/bin')
+        sudo('chmod 755 /usr/local/bin/salt_utils.py')
+        #
         sudo(
             'wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/%s/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh' %
             sha)
         sudo('chmod 755 /tmp/bootstrap-salt.sh')
         sudo(
-            '/tmp/bootstrap-salt.sh -A `cat /etc/tags/SaltMasterPrvIP` git v2014.1.4')
+            '/tmp/bootstrap-salt.sh -A ' + master_prv_ip + ' git v2014.1.4')
         env.host_string = 'ubuntu@%s' % master_public_ip
         sudo('salt-key -y -A')
 
@@ -113,16 +120,23 @@ def install_master():
     stack_public_ips.remove(master_public_ip)
     env.host_string = 'ubuntu@%s' % master_public_ip
     sha = '6080a18e6c7c2d49335978fa69fa63645b45bc2a'
-    sudo('wget https://raw.githubusercontent.com/ministryofjustice/bootstrap-salt/master/scripts/bootstrap-salt.sh -O /tmp/moj-bootstrap.sh')
-    sudo('chmod 755 /tmp/moj-bootstrap.sh')
-    sudo('/tmp/moj-bootstrap.sh')
+    # copy the salt_utils.py from local to EC2 and chmod it
+    d = os.path.dirname(__file__)
+    saltutils = d + "/salt_utils.py"
+    if not os.path.isfile(saltutils):
+        print "ERROR: Cannot find %s" % saltutils
+        sys.exit(1)
+    put(saltutils, '/tmp')
+    sudo('cp /tmp/salt_utils.py /usr/local/bin')
+    sudo('chmod 755 /usr/local/bin/salt_utils.py')
+    #
     sudo(
         'wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/%s/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh' %
         sha)
     sudo('chmod 755 /tmp/bootstrap-salt.sh')
     sudo(
-        '/tmp/bootstrap-salt.sh -M -A `cat /etc/tags/SaltMasterPrvIP`\
-         git v2014.1.4')
+        '/tmp/bootstrap-salt.sh -M -A ' + master_prv_ip +
+        ' git v2014.1.4')
     sudo('salt-key -y -A')
 
 

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -26,6 +26,7 @@ sys.path.append(os.path.dirname(path))
 
 env.stack = None
 
+
 @task
 def aws(x):
     env.aws = str(x).lower()
@@ -85,8 +86,7 @@ def install_minions():
         if not os.path.isfile(saltutils):
             print "ERROR: Cannot find %s" % saltutils
             sys.exit(1)
-        put(saltutils, '/tmp')
-        sudo('cp /tmp/salt_utils.py /usr/local/bin')
+        put(saltutils, '/usr/local/bin', use_sudo=True)
         sudo('chmod 755 /usr/local/bin/salt_utils.py')
         #
         sudo(
@@ -126,8 +126,8 @@ def install_master():
     if not os.path.isfile(saltutils):
         print "ERROR: Cannot find %s" % saltutils
         sys.exit(1)
-    put(saltutils, '/tmp')
-    sudo('cp /tmp/salt_utils.py /usr/local/bin')
+    put(saltutils, '/usr/local/bin', use_sudo=True)
+    sudo('chmod 755 /usr/local/bin/salt_utils.py')
     sudo('chmod 755 /usr/local/bin/salt_utils.py')
     #
     sudo(

--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-import utils
-import errors
 import salt
 import salt.runner
 import salt.client
@@ -8,15 +6,54 @@ import pprint
 import time
 import sys
 
+
+class BootstrapCfnError(Exception):
+
+    def __init__(self, msg):
+        print >> sys.stderr, "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
+
+
+class SaltStateError(BootstrapCfnError):
+    pass
+
+
+class SaltParserError(BootstrapCfnError):
+    pass
+
+
+class CfnTimeoutError(BootstrapCfnError):
+    pass
+
+
+def timeout(timeout, interval):
+
+    def decorate(func):
+
+        def wrapper(*args, **kwargs):
+            attempts = 0
+            while True:
+                result = func(*args, **kwargs)
+                if result:
+                    return result
+                if attempts >= timeout / interval:
+                    raise CfnTimeoutError("Timeout in {0}".format(func.__name__))
+                attempts += 1
+                time.sleep(interval)
+        return wrapper
+    return decorate
+
+
 def start_highstate(target):
     local = salt.client.LocalClient()
     jid = local.cmd_async(target, 'state.highstate')
     return jid
 
+
 def start_state(target, state):
     local = salt.client.LocalClient()
     jid = local.cmd_async(target, 'state.sls', [state])
     return jid
+
 
 def state_result(jid):
     opts = salt.config.master_config('/etc/salt/master')
@@ -26,15 +63,18 @@ def state_result(jid):
         return result
     return False
 
+
 def highstate(target, timeout, interval):
     jid = start_highstate(target)
-    res = utils.timeout(timeout, interval)(state_result)(jid)
+    res = timeout(timeout, interval)(state_result)(jid)
     return check_state_result(res)
+
 
 def state(target, state, timeout, interval):
     jid = start_state(target, state)
-    res = utils.timeout(timeout, interval)(state_result)(jid)
+    res = timeout(timeout, interval)(state_result)(jid)
     return check_state_result(res)
+
 
 def check_state_result(result):
     results = []
@@ -42,11 +82,12 @@ def check_state_result(result):
         if isinstance(ret, dict):
             results += [v['result'] for v in ret.values()]
         else:
-            raise errors.SaltParserError('Minion could not parse state data')
+            raise SaltParserError('Minion could not parse state data')
     if all(results):
         return True
     else:
-        raise errors.SaltStateError('State did not execute successfully')
+
+        raise SaltStateError('State did not execute successfully')
 
 if __name__ == "__main__":
     import argparse
@@ -57,11 +98,11 @@ if __name__ == "__main__":
                        help='Name of state or "highstate"', required=True)
     parser.add_argument('-T', dest='timeout', type=float,
                        help='Timeout to wait for state execution to finish'\
-                            'on all minions.', required=False, default = 1800)
+                            'on all minions.', required=False, default=1800)
     parser.add_argument('-I', dest='interval', type=float,
                        help='Interval to check for finished execution.',
                        required=False, default=10)
-                            
+
     args = parser.parse_args()
     if args.state == "highstate":
         highstate(args.target, args.timeout, args.interval)

--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -85,7 +85,6 @@ def check_state_result(result):
     if all(results):
         return True
     else:
-
         raise SaltStateError('State did not execute successfully')
 
 if __name__ == "__main__":

--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -25,7 +25,7 @@ class CfnTimeoutError(BootstrapCfnError):
     pass
 
 
-def timeout(timeout, interval):
+def do_timeout(timeout, interval):
 
     def decorate(func):
 
@@ -66,13 +66,13 @@ def state_result(jid):
 
 def highstate(target, timeout, interval):
     jid = start_highstate(target)
-    res = timeout(timeout, interval)(state_result)(jid)
+    res = do_timeout(timeout, interval)(state_result)(jid)
     return check_state_result(res)
 
 
 def state(target, state, timeout, interval):
     jid = start_state(target, state)
-    res = timeout(timeout, interval)(state_result)(jid)
+    res = do_timeout(timeout, interval)(state_result)(jid)
     return check_state_result(res)
 
 

--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -2,7 +2,6 @@
 import salt
 import salt.runner
 import salt.client
-import pprint
 import time
 import sys
 
@@ -93,15 +92,15 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='Run salt states')
     parser.add_argument('-t', dest='target', type=str,
-                       help='target', required=True)
+                        help='target', required=True)
     parser.add_argument('-s', dest='state', type=str,
-                       help='Name of state or "highstate"', required=True)
+                        help='Name of state or "highstate"', required=True)
     parser.add_argument('-T', dest='timeout', type=float,
-                       help='Timeout to wait for state execution to finish'\
-                            'on all minions.', required=False, default=1800)
+                        help='Timeout to wait for state execution to finish'
+                        'on all minions.', required=False, default=1800)
     parser.add_argument('-I', dest='interval', type=float,
-                       help='Interval to check for finished execution.',
-                       required=False, default=10)
+                        help='Interval to check for finished execution.',
+                        required=False, default=10)
 
     args = parser.parse_args()
     if args.state == "highstate":

--- a/tests/test_salt_util.py
+++ b/tests/test_salt_util.py
@@ -54,12 +54,12 @@ class SaltUtilTestCase(unittest.TestCase):
     def test_check_state_result_bad(self):
         result = {'minon1': {'state':{'result':False}},
                   'minion2': {'state':{'result':True}}} 
-        with self.assertRaises(errors.SaltStateError):
+        with self.assertRaises(salt_utils.SaltStateError):
             salt_utils.check_state_result(result)
 
     def test_check_state_result_parse_error(self):
         result = {'minon1': ['SOME SALT PARSER ERROR']}
-        with self.assertRaises(errors.SaltParserError):
+        with self.assertRaises(salt_utils.SaltParserError):
             salt_utils.check_state_result(result)
 
     def tearDown(self):

--- a/tests/test_salt_util.py
+++ b/tests/test_salt_util.py
@@ -1,6 +1,5 @@
 import unittest
 import mock
-from bootstrap_salt import errors
 import sys
 # This is a hack so that we don't need salt to run our tests
 sys.modules['salt'] = mock.Mock()
@@ -18,7 +17,7 @@ class SaltUtilTestCase(unittest.TestCase):
     def test_state_result(self):
         salt.config = mock.Mock()
         mock_result = mock.Mock()
-        mock_config = {'cmd.return_value': {'minon1': {'state':{'result':True}}}}
+        mock_config = {'cmd.return_value': {'minon1': {'state': {'result': True}}}}
         mock_result.configure_mock(**mock_config)
 
         mock_client = mock.Mock()
@@ -46,14 +45,14 @@ class SaltUtilTestCase(unittest.TestCase):
         self.assertFalse(x)
 
     def test_check_state_result_good(self):
-        result = {'minon1': {'state':{'result':True}},
-                  'minion2': {'state':{'result':True}}} 
+        result = {'minon1': {'state': {'result': True}},
+                  'minion2': {'state': {'result': True}}}
         x = salt_utils.check_state_result(result)
         self.assertTrue(x)
 
     def test_check_state_result_bad(self):
-        result = {'minon1': {'state':{'result':False}},
-                  'minion2': {'state':{'result':True}}} 
+        result = {'minon1': {'state': {'result': False}},
+                  'minion2': {'state': {'result': True}}}
         with self.assertRaises(salt_utils.SaltStateError):
             salt_utils.check_state_result(result)
 


### PR DESCRIPTION
This change puts salt_utils.py directly to the target server and no long uses the /tmp/moj-bootstrap.sh and ec2_tags.py scripts.
Before merging this PR, please make sure the following PR in template-deploy has been merged or template-deploy will break:
https://github.com/ministryofjustice/template-deploy/pull/39

Additionally: 
Applied some style fixes for PEP8 errors