### PR TITLE
Generate keys from github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.idea
+*.iml
+*.swp
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Version unreleased
 
 * Sync salt_utils script with every rsync.
+* Generate SSH keys from Github.
 
 ## Version 0.1.0
 

--- a/README.rst
+++ b/README.rst
@@ -103,3 +103,37 @@ The cloudformation yaml will be automatically uploaded to your pillar as cloudfo
 ::
 
     salt-call pillar.get s3:static-bucket-name
+
+Github based SSH key generation
++++++++++++++++++++++++++++++++
+Add this to your template yaml:
+
+::
+   
+    myenv:
+      github_users:
+        ministryofjustice: # or any org
+          individuals:
+            - koikonom:
+                fingerprints:
+                  - '35:53:6f:27:fe:39:8b:d8:dd:87:19:f3:40:d2:84:6a'
+                unix_username:
+                  kyriakos
+            - ashb:
+                fingerprints:
+                  - '0c:11:2b:78:ff:8d:5f:f0:dc:27:8e:e2:f8:2f:ab:25'
+                  - 'af:e0:6c:dc:bd:9b:bf:1d:9b:de:2d:de:12:6e:f2:8a'
+            - mattmb
+          teams:
+            - some-team-name
+              - some-user:
+                  unix_username: userunixusername
+                  fingerprints: 00:11:22:33:44:55:66
+            - anotherteam
+
+Running this requires a github token with permissions to read the github organisation stored in an environment variable called GH_TOKEN.
+Once you set the variable just run
+
+::
+fab application:<yourapp> aws:<your_aws_profile> environment:myenv config:<your template yaml file> ssh_keys
+

--- a/bootstrap_salt/deploy_lib/github.py
+++ b/bootstrap_salt/deploy_lib/github.py
@@ -1,0 +1,217 @@
+import base64
+import hashlib
+import os
+import requests
+
+
+API_ENDPOINT = 'https://api.github.com/'
+ORG = 'ministryofjustice'
+
+
+class GithubTokenMissing(Exception):
+    pass
+
+
+class GithubRequestException(Exception):
+    pass
+
+
+class InvalidTeamException(Exception):
+    pass
+
+
+class InvalidKey(Exception):
+    pass
+
+
+def get_github_token():
+    if 'GH_TOKEN' not in os.environ:
+        raise GithubTokenMissing('GH_TOKEN has not been defined.')
+    return os.environ['GH_TOKEN']
+
+
+def get_paginated_content(url, page=None, out=None, **kwargs):
+    if 'auth' not in kwargs:
+        kwargs['auth'] = (get_github_token(), 'x-oauth-basic')
+
+    if 'params' in kwargs:
+        kwargs['params'].update({'per_page': 100})
+    else:
+        kwargs['params'] = {'per_page': 100}
+    r = requests.get(url, **kwargs)
+    if r.status_code != 200:
+        raise GithubRequestException('GH API request failed with code: {}'
+                                     '\n{}'.format(r.status_code, r.text))
+
+    if not out:
+        out = r.json()
+    else:
+        out.extend(r.json())
+
+    if 'next' in r.links:
+        return get_paginated_content(r.links['next']['url'], out=out, **kwargs)
+    else:
+        return out
+
+
+def get_teams(org=ORG):
+    url = '{}orgs/{}/teams'.format(API_ENDPOINT, org)
+    response = get_paginated_content(url)
+    return response
+
+
+def get_org_members(org=ORG):
+    url = '{}orgs/{}/members'.format(org)
+    return get_paginated_content(url)
+
+
+def get_org_team(team_slug, org=ORG):
+    teams = get_teams(org)
+    team = filter(lambda x: x['slug'] == team_slug, teams)
+    if len(team) == 0:
+        raise InvalidTeamException(
+            'Team {} is not part of org {}'.format(team_slug, org))
+    else:
+        return team[0]
+
+
+def get_team_members(team_slug, org=ORG):
+    try:
+        team = get_org_team(team_slug, org)
+    except InvalidTeamException:
+        return {}
+    url = '{}teams/{}/members'.format(API_ENDPOINT, team['id'])
+    return get_paginated_content(url)
+
+
+def check_org_membership(org, user):
+    url = '{}orgs/{}/members/{}'.format(API_ENDPOINT, org, user)
+    r = requests.get(url, auth=(get_github_token(), 'x-oauth-basic'))
+    if r.status_code == 204:
+        return True
+    else:
+        return False
+
+
+def get_key_fingerprint(key):
+    toks = key['key'].split()
+    try:
+        (enc, key_body, descr) = key['key'].split()
+    except ValueError:
+        if len(toks) == 2:
+            (enc, key_body) = key['key'].split()
+        else:
+            raise InvalidKey('Invalid key: {}'.format(key['key']))
+    if enc not in ['ssh-rsa', 'ssh-dss', 'ssh-ecdsa']:
+        raise InvalidKey('Invalid enc type: {}'.format(enc))
+    key_bytes = base64.b64decode(key_body)
+    md5hash = hashlib.md5()
+    md5hash.update(key_bytes)
+    fingerprint = md5hash.hexdigest()
+    fingerprint = [fingerprint[i:i+2] for i in range(0, len(fingerprint), 2)]
+    return ':'.join(fingerprint)
+
+
+def get_user_keys(user, fingerprints=None):
+    keys = get_paginated_content('{}users/{}/keys'.format(API_ENDPOINT, user))
+    if fingerprints:
+        for key in keys:
+            fingerprint = get_key_fingerprint(key)
+            if fingerprint not in fingerprints:
+                keys.remove(key)
+    return keys
+
+
+def get_user_struct(username, user_data=None):
+    user_data = user_data if user_data else {}
+    fingerprints = user_data.get('fingerprints', None)
+    keys = get_user_keys(username, fingerprints=fingerprints)
+    username = user_data.get('unix_username', username)
+    fields = ('enc', 'key')
+    key_tuples = (key['key'].split(' ') for key in keys)
+    key_dict = [dict(zip(fields, map(str, x))) for x in key_tuples]
+    # The three lines above can be written in the form:
+    # [dict(zip(('enc', 'key'), key.split(' '))) for key in keys]
+    # ... but good luck figuring it out in a week from now
+    if not key_dict:
+        return {}
+    return {str(username): {'public_keys': key_dict}}
+
+
+def handle_string_team(team, org):
+    team_users = get_team_members(team, org)
+    return team_users, []
+
+
+def handle_dict_team(team, org):
+    team_name = team.keys()[0]
+    special_users = team[team_name]
+    team_users = get_team_members(team_name, org)
+    return team_users, special_users
+
+
+def get_keys(data):
+    out = {}
+    for org in data.keys():
+        for team in data[org].get('teams', []):
+            if isinstance(team, basestring):
+                team_users, special_users = handle_string_team(team, org)
+            elif isinstance(team, dict):
+                team_users, special_users = handle_dict_team(team, org)
+            else:
+                raise Exception('malformed data for team {}'.format(team))
+
+            for user in special_users:
+                user_struct = get_user_struct(*user.items()[0])
+                out.update(user_struct)
+
+            for user in team_users:
+                if user['login'] in special_users or user['login'] in out:
+                    continue
+                user_struct = get_user_struct(user['login'])
+                out.update(user_struct)
+
+        for user in data[org].get('individuals', []):
+            s_user, s_user_data = user.items()[0] \
+                if isinstance(user, dict) else (user, {})
+            out.update(get_user_struct(s_user, s_user_data))
+    return out
+
+
+if __name__ == '__main__':
+    data = {
+        'ministryofjustice': {
+            'individuals': [
+                {
+                    'koikonom': {
+                        'fingerprints':
+                            ['35:53:6f:27:fe:39:8b:d8:dd:87:19:f3:40:d2:84:6a'],
+                        'unix_username': 'kyriakos'
+                    }
+                }, {
+                    'ashb': {
+                        'fingerprints':
+                            ['0c:11:2b:78:ff:8d:5f:f0:dc:27:8e:e2:f8:2f:ab:25',
+                             'af:e0:6c:dc:bd:9b:bf:1d:9b:de:2d:de:12:6e:f2:8a',
+                             ]
+                    }
+                },
+                'mattmb'
+            ],
+            'teams': [
+                {
+                    'prison-visits-booking': [
+                        {
+                            'jasiek': {
+                                'unix_username': 'jan',
+                                'fingerprint': '00:11:22:33'
+                            }
+                        }
+                    ]
+                },
+                'civil-claims'
+            ]
+        }
+    }
+    # print yaml.dump(get_keys(data), default_flow_style=False)
+    print get_keys(data)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ setup(
         'PyYAML>=3.11',
         'boto>=2.36.0',
         'bootstrap-cfn>=0.4.1',
+        'requests',
+        'ndg-httpsclient'
     ],
     setup_requires=[
         'mock>=1.0.1',

--- a/tests/github_tests.py
+++ b/tests/github_tests.py
@@ -1,0 +1,153 @@
+import unittest
+import urlparse
+
+import mock
+
+from bootstrap_salt.deploy_lib import github
+
+
+class GithubTest(unittest.TestCase):
+
+    def setUp(self):
+        token_mock = mock.MagicMock(return_value='sometoken')
+        content_mock = mock.Mock(side_effect=self.content_side_effect)
+        github.get_github_token = token_mock
+        github.get_paginated_content = content_mock
+
+        self.orgs_document = [
+            {'slug': 'teamA', 'id': '123456'},
+            {'slug': 'teamB', 'id': '789012'},
+        ]
+
+        rsa_pub_key = '''ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA5KtkJ1gcLKYa''' \
+                      '''EKzCzEd7A4iP7LKs8Fx87TT0fElrIYP7CoSGaK4DaOkkYhyOX''' \
+                      '''gV2Togj1kRUpgazwiybi/5xW0T8RUZa9kSPp9zJADTiTR8TOU''' \
+                      '''Wu1pl/nRMKUdmooY6LHtfOML633FX/Aj5OeiA7RfiEZv5odNRt''' \
+                      '''Tlz8m9eZsMs= sample_rsa_key'''
+
+        dsa_pub_key = '''ssh-dss AAAAB3NzaC1kc3MAAACBAPq/cb/flXMYNzrnCyF9Q''' \
+                      '''IlVYWZa+uCGQ2pBvwIRMrsFk+lrVgWqV6eVL6DVgjz8n1rphf''' \
+                      '''qYCg12SNhkKLY3vbf6656iO7V+bFt6zmWdp6CmVyATMPEImsd''' \
+                      '''b1q+p32xRCUC+zVA5hSyMdW7RUVBQiIDUScNb13AVpom72A''' \
+                      '''eP0IHJAAAAFQDOBHsfqF37SdIcQClH9HJQSYY9vQAAAIEA''' \
+                      '''souZoZRi2ruS0E7P+oM6zKjIJR2If4m1SWDcEyh2RHaGBX''' \
+                      '''l9sCPpBnIgrCmXKD4OBd52UnyIau4FYGj3FuNoo8AMUhcna8''' \
+                      '''xvc4pH9RJd70syC6yub1r00qVsaiqULYIe+lh06TqPLEt+yn''' \
+                      '''TVDMm7Mk9Gd4M7IKy3DqKdffZtGCUAAACBAJ16Kvvr6YDm644x''' \
+                      '''UqUax5cktrKyW730Do0xmAGStxP5TMHCDgMNlkcdcTpReJxaOS''' \
+                      '''hgnpvysdUrkMjbI/UPTkcJRtonVE4K7tTs4y0/zpCxa812haG8''' \
+                      '''dTOABK9rioyos57v3qkemrqBy9f7DNUk3cRXkmiPphIxoO87Hm''' \
+                      '''NDBCjI sample_dsa_key'''
+        invalid_pub_key = 'ssh-notvalid blah invalid_key'
+        not_a_key = 'notakey'
+        self.public_keys = {
+            'rsa': {
+                'key': rsa_pub_key,
+                'fingerprint': '09:05:ee:46:39:5d:87:e2:05:42:07:0b:c7:4a:63:a9'
+            },
+            'dsa': {
+                'key': dsa_pub_key,
+                'fingerprint': '35:53:6f:27:fe:39:8b:d8:dd:87:19:f3:40:d2:84:6a'
+            },
+            'invalid': {
+                'key': invalid_pub_key,
+                'fingerprint': 'blah'
+            },
+            'not_a_key': {
+                'key': not_a_key,
+                'fingerprint': 'blah'
+            }
+        }
+
+        self.users_document = [self.public_keys['rsa'], self.public_keys['dsa']]
+
+    def handle_orgs_request(self, path):
+        return self.orgs_document
+
+    def handle_users_request(self, path):
+        if path.split('/')[-1] == 'keys':
+            user = path.split('/')[2]
+            if user == 'good_user':
+                return [self.public_keys['rsa']]
+            elif user == 'bad_user':
+                raise github.GithubRequestException
+            elif user == 'good_invalid_keys':
+                return [self.public_keys['invalid']]
+            elif user == 'good_no_keys':
+                return []
+            elif user == 'good_all_keys':
+                return [self.public_keys['rsa'], self.public_keys['dsa']]
+
+    def content_side_effect(self, *args, **kwargs):
+        # immitate github's api responses
+        if not args:
+            raise Exception
+        url = args[0]
+        path = urlparse.urlparse(url).path
+        responses_map = {
+            'orgs': self.handle_orgs_request,
+            'users': self.handle_users_request
+            }
+        if path == '/':
+            return {}
+        return responses_map.get(path.split('/')[1])(path)
+
+    def test_get_org_team(self):
+        # test existing team
+        x = github.get_org_team('teamA')
+        self.assertEquals(x['slug'], 'teamA')
+
+        # test non existing team
+        self.assertRaises(github.InvalidTeamException,
+                          github.get_org_team, 'nonexistingteam')
+
+    def test_get_key_fingerprint(self):
+
+        # test rsa fingerprint
+        rsa_fingerprint = github.get_key_fingerprint(self.public_keys['rsa'])
+        self.assertEquals(rsa_fingerprint,
+                          self.public_keys['rsa']['fingerprint'])
+
+        # test dsa fingeprint
+        dsa_fingerprint = github.get_key_fingerprint(self.public_keys['dsa'])
+        self.assertEquals(dsa_fingerprint,
+                          self.public_keys['dsa']['fingerprint'])
+
+        # test invalid key format
+        self.assertRaises(github.InvalidKey,
+                          github.get_key_fingerprint,
+                          self.public_keys['invalid'])
+
+        # test invalid string
+        self.assertRaises(github.InvalidKey,
+                          github.get_key_fingerprint,
+                          self.public_keys['not_a_key'])
+
+    def test_get_user_keys(self):
+
+        # existing user with key
+        self.assertEquals(github.get_user_keys('good_user'),
+                          [self.public_keys['rsa']])
+
+        # non existing user
+        self.assertRaises(github.GithubRequestException, github.get_user_keys,
+                          'bad_user')
+
+        # existing user with no keys
+        self.assertEquals([], github.get_user_keys('good_no_keys'))
+
+        # existing user with multiple keys filtered by fingerprint
+        self.assertEquals(
+            [self.public_keys['rsa']],
+            github.get_user_keys(
+                'good_all_keys',
+                fingerprints=[self.public_keys['rsa']['fingerprint']]))
+
+        # existing user with single key and multiple fingerprints
+        # in the fingerprint list
+        self.assertEquals(
+            [self.public_keys['rsa']],
+            github.get_user_keys(
+                'good_user',
+                fingerprints=[self.public_keys['rsa']['fingerprint'],
+                              self.public_keys['rsa']['fingerprint']]))


### PR DESCRIPTION
Closes ministryofjustice/platforms-team#2

Add this to your template yaml:
```
  github_users:
    ministryofjustice: # or any org
      individuals:
        - koikonom:
            fingerprints:
              - '35:53:6f:27:fe:39:8b:d8:dd:87:19:f3:40:d2:84:6a'
            unix_username:
              kyriakos
        - ashb:
            fingerprints:
              - '0c:11:2b:78:ff:8d:5f:f0:dc:27:8e:e2:f8:2f:ab:25'
              - 'af:e0:6c:dc:bd:9b:bf:1d:9b:de:2d:de:12:6e:f2:8a'
        - mattmb
      teams:
        - some-team-name
          - some-user:
              unix_username: userunixusername
              fingerprints: 00:11:22:33:44:55:66
        - anotherteam
```
When you run fab task ssh_keys it will generate a fil in <pillar_dir>/<env>/keys.sls,
where <env> depends on the environment you put the github_users in your template
YAML file.

Note: Running this requires a github token with permissions to read the github
organisation stored in an environment variable called GH_TOKEN.