### PR TITLE
Sync salt-util script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version unreleased
+
+* Sync salt_utils script with every rsync.
+
 ## Version 0.1.0
 
 First release to PyPi


### PR DESCRIPTION
This encourages non breaking changes by syncing the salt_utils script whenever the rsync task is run.

If we merge this and then tag a new release then it will be safe to merge:
https://github.com/ministryofjustice/template-deploy/pull/45 (once we update the version)

@ashb just testing this now...