### PR TITLE
Install salt on all the minions.

### DIFF
--- a/bootstrap_salt/cloudformation.py
+++ b/bootstrap_salt/cloudformation.py
@@ -7,6 +7,7 @@ import utils
 class Cloudformation(object):
 
     conn_cfn = None
+    conn_ec2 = None
     aws_region_name = None
     aws_profile_name = None
 
@@ -14,28 +15,40 @@ class Cloudformation(object):
         self.aws_profile_name = aws_profile_name
         self.aws_region_name = aws_region_name
         self.conn_cfn = utils.connect_to_aws(boto.cloudformation, self)
+        self.conn_ec2 = utils.connect_to_aws(boto.ec2, self)
 
-    def get_stack_instances(self, stack_name_or_id):
-        # get the stack
+    def get_stack_id(self, stack_name_or_id):
+        """
+        Takes a stack name or id and converts it to the id
+        """
         stack = self.conn_cfn.describe_stacks(stack_name_or_id)
-        print "Stack:", stack
-        if not stack:
-            print 'Empty stack'
+        if len(stack) > 1:
+            raise RuntimeError("get_stack_id expected 0 or 1 stacks, but got {0}".format(len(stack)))
+
+        return stack[0].stack_id if len(stack) else None
+
+    def filter_stack_instances(self, stack_name_or_id, filters):
+        stack_id = self.get_stack_id(stack_name_or_id)
+
+        if not stack_id:
             return []
-        fn = lambda x: x.resource_type == 'AWS::AutoScaling::AutoScalingGroup'
-        # get the scaling group
-        scaling_group = filter(fn, stack[0].list_resources())
-        if not scaling_group:
-            print 'No scaling group found'
-            return []
-        scaling_group_id = scaling_group[0].physical_resource_id
 
-        asc = utils.connect_to_aws(autoscale, self)
+        filters = filters.copy()
+        filters['tag:aws:cloudformation:stack-id'] = stack_id
 
-        # get the instance IDs for all instances in the scaling group
-        instances = asc.get_all_groups(names=[scaling_group_id])[0].instances
-        return instances
+        resv = self.conn_ec2.get_all_reservations(filters=filters)
+        return [i for r in resv for i in r.instances]
 
-    def get_stack_instance_ids(self, stack_name_or_id):
+    def get_stack_instances(self, stack_name_or_id, running_only=True):
+        """
+        Return boto Instance objects for every instance belonging to the stack
+        """
+        filters = {}
+        if running_only:
+            filters['instance-state-name'] = 'running'
+
+        return self.filter_stack_instances(stack_name_or_id, filters=filters)
+
+    def get_stack_instance_ids(self, stack_name_or_id, running_only=True):
         return [
-            x.instance_id for x in self.get_stack_instances(stack_name_or_id)]
+            x.id for x in self.get_stack_instances(stack_name_or_id, running_only=running_only)]

--- a/bootstrap_salt/ec2.py
+++ b/bootstrap_salt/ec2.py
@@ -54,15 +54,11 @@ class EC2:
         resv = self.conn_ec2.get_all_reservations([inst_id])
         return [i for r in resv for i in r.instances][0] if resv else None
 
-    def get_master_instance(self, stack_name_or_id,
-                            master_tag_name='SaltMaster'):
-        stack_instances = self.cfn.get_stack_instances(stack_name_or_id)
-        stack_instance_ids = [x.instance_id for x in stack_instances]
-        filters = {'tag-key': master_tag_name,
-                   'instance-state-name': 'running',
-                   'instance-id': stack_instance_ids}
-        resv = self.conn_ec2.get_all_reservations(filters=filters)
-        return [i for r in resv for i in r.instances][0] if resv else None
+    def get_master_instance(self, stack_name_or_id):
+        instances = self.cfn.filter_stack_instances(
+            stack_name_or_id,
+            filters={'tag-key': 'SaltMaster'})
+        return instances[0] if len(instances) else None
 
     def get_minions(self, stack_name_or_id,
                     minion_tag_name='SaltMasterPrvIP', remove_master=False):

--- a/bootstrap_salt/ec2.py
+++ b/bootstrap_salt/ec2.py
@@ -60,17 +60,26 @@ class EC2:
             filters={'tag-key': 'SaltMaster'})
         return instances[0] if len(instances) else None
 
-    def get_minions(self, stack_name_or_id,
-                    minion_tag_name='SaltMasterPrvIP', remove_master=False):
-        stack_instances = self.cfn.get_stack_instances(stack_name_or_id)
-        stack_instance_ids = [x.instance_id for x in stack_instances]
-        resv = self.conn_ec2.get_all_reservations(
-            filters={'tag-key': minion_tag_name,
-                     'instance-id': stack_instance_ids})
-        instances = [i for r in resv for i in r.instances]
-        if remove_master:
-            instances.remove(self.get_master_instance(stack_name_or_id))
-        return instances
+    def get_unconfigured_minions(self, stack_name_or_id, master_ip):
+        """
+        Get a list of all instances that need salt_master configuring.
+
+        We define configuring as:
+
+        - They haven't had salt installed (which would be the case when there
+          is no 'SaltMasterPrvIP' tag
+        - They are speaking to the wrong master (which would be if the salt
+          master had to be re-built)
+
+        """
+        instances = self.cfn.get_stack_instances(stack_name_or_id)
+        unconfigured = []
+        for i in instances:
+            if i.tags.get('SaltMasterPrvIP', '') == master_ip or i.tags.get('SaltMaster', ''):
+                continue
+
+            unconfigured.append(i)
+        return unconfigured
 
     def is_ssh_up_on_all_instances(self, stack_id):
         """

--- a/tests/test.py
+++ b/tests/test.py
@@ -236,6 +236,32 @@ class BootstrapSaltTestCase(unittest.TestCase):
         self.assertFalse(ec.is_ssh_up_on_all_instances(self.stack_name))
         ssh_mock.assert_has_calls([mock.call('1.2.3.4'), mock.call('2.3.4.5')])
 
+    def test_get_unconfigured_minions(self):
+        ec = ec2.EC2(self.env.aws_profile)
+
+        master_prv_ip = '10.0.0.1'
+
+        master = mock.Mock(name="MockInstanceMaster")
+        type(master).tags = mock.PropertyMock(return_value={'SaltMaster': 'True', 'SaltMasterPrvIP': master_prv_ip})
+
+        # An unconfigured minion
+        minion_1 = mock.Mock(name="MockInstance1")
+        type(minion_1).tags = mock.PropertyMock(return_value={})
+
+        # To the wrong master
+        minion_2 = mock.Mock(name="MockInstance2")
+        type(minion_2).tags = mock.PropertyMock(return_value={'SaltMasterPrvIP': '10.0.0.2'})
+
+        # Correctly
+        minion_3 = mock.Mock(name="MockInstance3")
+        type(minion_3).tags = mock.PropertyMock(return_value={'SaltMasterPrvIP': master_prv_ip})
+
+        ec.cfn.get_stack_instances = mock.Mock(return_value=[master, minion_1, minion_2, minion_3])
+
+        got = ec.get_unconfigured_minions(self.stack_name, master_prv_ip)
+        expected = [minion_1, minion_2]
+        self.assertEqual(got, expected)
+
     def test_is_ssh_up(self):
         mock_p = mock.Mock()
         mock_client = mock.Mock()


### PR DESCRIPTION
We had a bug where we weren't actually installing salt on to anything other
than the master minion

- Don’t tag the minions with ‘SaltMasterPrvIP’ untill we have actually
  installed it

- Move code out of the fab_tasks file

- Simplify how we get/filter minions from a Cloudformation stack

  We can simply filter via the auto-created tag that AWS creates for us -
  ‘aws:cloudformation:stack-id’