### PR TITLE
Add batch functionality to salt_utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Make it possible to target minions in batches by passing a decimal fraction to the salt_utils script.
+
 ## Version 0.1.2
 
 * Bug fix: import the correct config from bootstrap_cfn

--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -9,21 +9,21 @@ import sys
 import math
 
 
-class BootstrapCfnError(Exception):
+class BootstrapUtilError(Exception):
 
     def __init__(self, msg):
         print >> sys.stderr, "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
 
 
-class SaltStateError(BootstrapCfnError):
+class SaltStateError(BootstrapUtilError):
     pass
 
 
-class SaltParserError(BootstrapCfnError):
+class SaltParserError(BootstrapUtilError):
     pass
 
 
-class CfnTimeoutError(BootstrapCfnError):
+class UtilTimeoutError(BootstrapUtilError):
     pass
 
 
@@ -59,7 +59,7 @@ def do_timeout(timeout, interval):
                 if result:
                     return result
                 if attempts >= timeout / interval:
-                    raise CfnTimeoutError("Timeout in {0}".format(func.__name__))
+                    raise UtilTimeoutError("Timeout in {0}".format(func.__name__))
                 attempts += 1
                 time.sleep(interval)
         return wrapper

--- a/tests/test_salt_util.py
+++ b/tests/test_salt_util.py
@@ -16,6 +16,49 @@ class SaltUtilTestCase(unittest.TestCase):
     def setUp(self):
         pass
 
+    def test_get_minions_batch(self):
+        mock_result = mock.Mock()
+        # No batch
+        mock_config = {'cmd.return_value': {'minion1': 'blah',
+                                            'minion2': 'blah'}}
+        mock_result.configure_mock(**mock_config)
+        mock_client = mock.Mock()
+        mock_client.return_value = mock_result
+        mock_c = mock.Mock(LocalClient=mock_client)
+        salt.client = mock_c
+        x = salt_utils.get_minions_batch('*')
+        expected = [['minion1', 'minion2']]
+        self.assertEqual(x, expected)
+
+        # 50% batch
+        mock_config = {'cmd.return_value': {'minion1': 'blah',
+                                            'minion2': 'blah',
+                                            'minion3': 'blah',
+                                            'minion4': 'blah'}}
+        mock_result.configure_mock(**mock_config)
+        mock_client = mock.Mock()
+        mock_client.return_value = mock_result
+        mock_c = mock.Mock(LocalClient=mock_client)
+        salt.client = mock_c
+
+        x = salt_utils.get_minions_batch('*', 0.5)
+        expected = [['minion4', 'minion1'], ['minion3', 'minion2']]
+        self.assertEqual(x, expected)
+
+        # 50% batch uneven minons
+        mock_config = {'cmd.return_value': {'minion1': 'blah',
+                                            'minion2': 'blah',
+                                            'minion3': 'blah'}}
+        mock_result.configure_mock(**mock_config)
+        mock_client = mock.Mock()
+        mock_client.return_value = mock_result
+        mock_c = mock.Mock(LocalClient=mock_client)
+        salt.client = mock_c
+
+        x = salt_utils.get_minions_batch('*', 0.5)
+        expected = [['minion1', 'minion3'], ['minion2']]
+        self.assertEqual(x, expected)
+
     def test_state_result(self):
         salt.config = mock.Mock()
         mock_result = mock.Mock()


### PR DESCRIPTION
This makes it possible to run states/highstates against a batch of minions whilst still checking for errors, printing output and stopping if there is a failure.