### PR TITLE
Fix import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.x
+
+* Bug fix: import the correct config from bootstrap_cfn
+
 ## Version 0.1.1
 
 * Sync salt_utils script with every rsync.

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -8,10 +8,11 @@ import yaml
 import logging
 logging.basicConfig(level=logging.INFO)
 
+import bootstrap_cfn.config as config
 from fabric.api import env, task, sudo, put, run
 from fabric.contrib.project import upload_project
 from bootstrap_cfn.fab_tasks import _validate_fabric_env, \
-    get_stack_name, get_config, config
+    get_stack_name, get_config
 
 from cloudformation import Cloudformation
 from ec2 import EC2


### PR DESCRIPTION
Import bootstrap_cfn.config instead of config from bootstrap_cfn.fab_tasks. This fixes an issue that caused almost any fab task to raise an AttributeError exception, as the incorrect config function was called.