### PR TITLE
(WIP) Add Boto3 in addition to Boto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Fabric==1.10.1
 PyYAML==3.11
 boto==2.36.0
+boto3
 mock==1.0.1
 dnspython

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         'Fabric>=1.10.1',
         'PyYAML>=3.11',
         'boto>=2.36.0',
+        'boto3',
         'bootstrap-cfn>=0.5.1',
         'requests',
         'ndg-httpsclient',


### PR DESCRIPTION
@mattmb Add Boto3 Can you please check - I am assuming that for the time being the boto config stays the same? 

(Boto3, the next version of Boto, is now stable and recommended for general use. It can be used side-by-side with Boto in the same project....) see https://waffle.io/ministryofjustice/platforms-team/cards/55a587113045614d0001e750.