### PR TITLE
Remove salt master

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include contrib/*

--- a/bootstrap_salt/config.py
+++ b/bootstrap_salt/config.py
@@ -2,6 +2,10 @@ import os
 import pkg_resources
 import pkgutil
 
+from troposphere import Join, Ref
+from troposphere.iam import PolicyType
+from troposphere.s3 import Bucket
+
 from bootstrap_cfn.config import ConfigParser
 
 from fabric.api import env
@@ -11,9 +15,60 @@ import yaml
 
 class MyConfigParser(ConfigParser):
 
+    def __init__(self, *args, **kwargs):
+        try:
+            self.kms_key_id = env.kms_key_id
+            self.kms_data_key = env.kms_data_key
+        except AttributeError:
+            pass
+        super(MyConfigParser, self).__init__(*args, **kwargs)
+
     def base_template(self):
         ret = super(MyConfigParser, self).base_template()
-        ret.add_mapping('KMS', {'salt': {'key': env.kms_key_id}})
+
+        salt_bucket = Bucket(
+            "SaltBucket",
+            AccessControl="BucketOwnerFullControl",
+            BucketName="{0}-salt".format(self.stack_name)
+        )
+        ret.add_resource(salt_bucket)
+
+        arn = Join("", ["arn:aws:s3:::", Ref(salt_bucket), "/*"])
+        salt_bucket_policy = {
+            'Action': ['s3:Get*',
+                       's3:List*'],
+            "Resource": arn,
+            'Effect': 'Allow'}
+        salt_role_policy = PolicyType(
+            "S3SaltPolicy",
+            PolicyName="S3SaltPolicy",
+            PolicyDocument={"Statement": [salt_bucket_policy]},
+            Roles=[Ref("BaseHostRole")],
+        )
+        ret.add_resource(salt_role_policy)
+
+        arn = Join("", ["arn:aws:kms:", Ref('AWS::Region'),
+                        ':',
+                        Ref('AWS::AccountId'),
+                        ':key/',
+                        self.kms_key_id])
+        kms_policy = {
+            "Sid": "AllowUseOfTheKey",
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt",
+                "kms:DescribeKey"
+            ],
+            "Resource": arn
+        }
+        kms_role_policy = PolicyType(
+            "KMSPolicy",
+            PolicyName="KMSPolicy",
+            PolicyDocument={"Statement": [kms_policy]},
+            Roles=[Ref("BaseHostRole")],
+        )
+        ret.add_resource(kms_role_policy)
+
         return ret
 
     def get_ec2_userdata(self):
@@ -23,7 +78,7 @@ class MyConfigParser(ConfigParser):
         bs_path = os.path.dirname(pkgutil.get_loader('bootstrap_salt').filename)
         script = os.path.join(bs_path, './contrib/bootstrap.sh')
         files = {'write_files': [{'encoding': 'b64',
-                                  'content': env.kms_data_key,
+                                  'content': self.kms_data_key,
                                   'owner': 'root:root',
                                   'path': '/etc/salt.key.enc',
                                   'permissions': '0600'},

--- a/bootstrap_salt/config.py
+++ b/bootstrap_salt/config.py
@@ -1,0 +1,37 @@
+import os
+import pkgutil
+
+from bootstrap_cfn.config import ConfigParser
+
+from fabric.api import env
+
+import yaml
+
+
+class MyConfigParser(ConfigParser):
+
+    def base_template(self):
+        ret = super(MyConfigParser, self).base_template()
+        ret.add_mapping('KMS', {'salt': {'key': env.kms_key_id}})
+        return ret
+
+    def get_ec2_userdata(self):
+        ret = super(MyConfigParser, self).get_ec2_userdata()
+
+        bs_path = os.path.dirname(pkgutil.get_loader('bootstrap_salt').filename)
+        script = os.path.join(bs_path, './contrib/bootstrap.sh')
+        files = {'write_files': [{'encoding': 'b64',
+                                  'content': env.kms_data_key,
+                                  'owner': 'root:root',
+                                  'path': '/etc/salt.key.enc',
+                                  'permissions': '0600'},
+                                 {'content': open(script).read(),
+                                  'owner': 'root:root',
+                                  'path': '/tmp/bootstrap.sh',
+                                  'permissions': '0700'}]}
+
+        ret.append({
+            'content': yaml.dump(files),
+            'mime_type': 'text/cloud-config'
+        })
+        return ret

--- a/bootstrap_salt/config.py
+++ b/bootstrap_salt/config.py
@@ -1,4 +1,5 @@
 import os
+import pkg_resources
 import pkgutil
 
 from bootstrap_cfn.config import ConfigParser
@@ -16,6 +17,7 @@ class MyConfigParser(ConfigParser):
         return ret
 
     def get_ec2_userdata(self):
+        self.__version__ = pkg_resources.get_distribution("bootstrap_salt").version
         ret = super(MyConfigParser, self).get_ec2_userdata()
 
         bs_path = os.path.dirname(pkgutil.get_loader('bootstrap_salt').filename)
@@ -29,7 +31,11 @@ class MyConfigParser(ConfigParser):
                                   'owner': 'root:root',
                                   'path': '/tmp/bootstrap.sh',
                                   'permissions': '0700'}]}
-
+        commands = {'runcmd': ['/tmp/bootstrap.sh v{0}'.format(self.__version__)]}
+        ret.append({
+            'content': yaml.dump(commands),
+            'mime_type': 'text/cloud-config'
+        })
         ret.append({
             'content': yaml.dump(files),
             'mime_type': 'text/cloud-config'

--- a/bootstrap_salt/ec2.py
+++ b/bootstrap_salt/ec2.py
@@ -58,33 +58,6 @@ class EC2:
         resv = self.conn_ec2.get_all_reservations([inst_id])
         return [i for r in resv for i in r.instances][0] if resv else None
 
-    def get_master_instance(self, stack_name_or_id):
-        instances = self.cfn.get_stack_instances(
-            stack_name_or_id,
-            filters={'tag-key': 'SaltMaster'})
-        return instances[0] if len(instances) else None
-
-    def get_unconfigured_minions(self, stack_name_or_id, master_ip):
-        """
-        Get a list of all instances that need salt_master configuring.
-
-        We define configuring as:
-
-        - They haven't had salt installed (which would be the case when there
-          is no 'SaltMasterPrvIP' tag
-        - They are speaking to the wrong master (which would be if the salt
-          master had to be re-built)
-
-        """
-        instances = self.cfn.get_stack_instances(stack_name_or_id)
-        unconfigured = []
-        for i in instances:
-            if i.tags.get('SaltMasterPrvIP', '') == master_ip or i.tags.get('SaltMaster', ''):
-                continue
-
-            unconfigured.append(i)
-        return unconfigured
-
     def is_ssh_up_on_all_instances(self, stack_id):
         """
         Returns False if no instances found

--- a/bootstrap_salt/ec2.py
+++ b/bootstrap_salt/ec2.py
@@ -21,6 +21,10 @@ class EC2:
             aws_region_name=aws_region_name
         )
 
+    def get_stack_instance_public_ips(self, stack_name):
+        instance_ids = self.cfn.get_stack_instance_ids(stack_name)
+        return self.get_instance_public_ips(instance_ids)
+
     def get_instance_public_ips(self, instance_id_list):
         if not instance_id_list:
             return []

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -12,12 +12,11 @@ import base64
 logging.basicConfig(level=logging.INFO)
 
 import bootstrap_cfn.config as config
-from fabric.api import env, task, run, local, settings, get
+from fabric.api import env, task, local, get
 from fabric.contrib import files
 from bootstrap_cfn.fab_tasks import _validate_fabric_env, \
     get_stack_name, get_config, cfn_create
 
-from cloudformation import Cloudformation
 from ec2 import EC2
 from bootstrap_salt.kms import KMS
 import bootstrap_salt.utils as utils

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -1,27 +1,25 @@
 #!/usr/bin/env python
 
 import os
-from StringIO import StringIO
 import sys
-import random
-import string
 import yaml
-from tempfile import mkdtemp
+import tempfile
 import logging
 import pkgutil
+import gnupg
+import base64
 logging.basicConfig(level=logging.INFO)
 
 import bootstrap_cfn.config as config
-from fabric.api import env, task, sudo, put, run, local
-from fabric.contrib.project import upload_project
-import dns.resolver
+from fabric.api import env, task, run, local, settings, get
+from fabric.contrib import files
 from bootstrap_cfn.fab_tasks import _validate_fabric_env, \
-    get_stack_name, get_config
+    get_stack_name, get_config, cfn_create
 
 from cloudformation import Cloudformation
 from ec2 import EC2
-from bootstrap_cfn.r53 import R53
-import bootstrap_salt
+from bootstrap_salt.kms import KMS
+import bootstrap_salt.utils as utils
 from bootstrap_salt.config import MyConfigParser
 
 from .deploy_lib import github
@@ -108,216 +106,113 @@ def application(application_name):
     env.application = str(application_name).lower()
 
 
-@task
-def setup(salt_version='v2014.7.5'):
+def get_kms_key_id():
     """
-    Setup the salt master and minions
+    Returns an id for a KMS master key with an alias of:
+    application-environment. If no key exists it will create a
+    new one.
+    """
+    alias = "{0}-{1}".format(env.application, env.environment)
+    kms = get_connection(KMS)
+    key_id = kms.get_key_id(alias)
+    if not key_id:
+        key_id = kms.create_key(alias)
+    return key_id
 
-    Call install_master and install_minions to setup salt
+
+def create_kms_data_key():
     """
-    install_master(salt_version)
-    install_minions(salt_version)
+    Returns an encrypted version of a new data key, generated
+    by KMS. The encrypted blob can be decrypted in the future
+    by anyone with the contents of the blob and access to the KMS
+    master key via IAM.
+    """
+    kms = get_connection(KMS)
+    return kms.generate_data_key(get_kms_key_id())
+
+bcfn_create = cfn_create
+
+
+@task
+def cfn_create(test=False):
+    """
+    Here we override the cfn_create task from bootstrap_cfn so that we
+    can inject the KMS key ID and encrypted key into the fabric environment.
+    """
+    env.kms_key_id = get_kms_key_id()
+    env.kms_data_key = create_kms_data_key()
+    bcfn_create(test=test)
+
+
+def get_instance_ips():
+    """
+    Get a list of the public IPs of the current instances in the stack.
+    """
+    ec2 = get_connection(EC2)
+    stack_name = get_stack_name()
+    return ec2.get_stack_instance_public_ips(stack_name)
+
+
+@task
+def wait_for_minions(timeout=600, interval=20):
+    """
+    This task ensures that the initial bootstrap has finished on all
+    stack instances.
+
+    Args:
+        timeout(int): time to wait for bootstrap to finish
+        interval(int): time to wait inbetween checks
+    """
+    _validate_fabric_env()
+    stack_name = get_stack_name()
+    ec2 = get_connection(EC2)
+    print "Waiting for SSH on all instances..."
+    ec2.wait_for_ssh(stack_name)
+    fab_hosts = get_instance_ips()
+    print "Waiting for bootstrap script to finish on all instances..."
+    utils.timeout(timeout, interval)(is_bootstrap_done)(fab_hosts)
+
+
+def is_bootstrap_done(hosts):
+    """
+    Loops through a list of IPs and checks for the prescence of
+    /tmp/bootstrap_done to ensure that the launch config has finished
+    executing.
+
+    Args:
+        hosts(list): A list of IPs to check
+    """
+    ret = []
+    for host in hosts:
+        env.host_string = '{0}@{1}'.format(env.user, host)
+        ret.append(files.exists('/tmp/bootstrap_done'))
+    return all(ret)
 
 
 def get_connection(klass):
+    """
+    Helper method to get connection to AWS
+
+    Args:
+        klass(class): The AWS class to setup the connection to.
+    """
     _validate_fabric_env()
     return klass(env.aws, env.aws_region)
 
-@task
-def mmb1():
-    stack_name = get_stack_name()
-    print stack_name
-
-def get_master_ip():
-    _validate_fabric_env()
-    stack_name = get_stack_name()
-    ec2 = get_connection(EC2)
-    master = ec2.get_master_instance(stack_name).ip_address
-    print 'Salt master public address: {0}'.format(master)
-    return master
-
 
 @task
-def swap_masters(tag1, tag2):
+def upload_salt():
     """
-    Swap two tagged stacks.
-    """
-    cfn_config = get_config()
-    r53_conn = get_connection(R53)
-    try:
-        zone_name = cfn_config.data['master_zone']
-    except KeyError:
-        logging.warn("master_zone not found in config file, "
-                     "so cannot swap master tags as they do "
-                     "not exist. Recreate stacks after adding "
-                     "master zone to the yaml config.")
-        sys.exit(1)
-    zone_id = r53_conn.get_hosted_zone_id(zone_name)
-    master1 = 'master.{0}.{1}.{2}'.format(tag1,
-                                          env.environment,
-                                          env.application)
-    master2 = 'master.{0}.{1}.{2}'.format(tag2,
-                                          env.environment,
-                                          env.application)
-    master_ip_1 = r53_conn.get_record(zone_name, zone_id, master1, 'A')
-    master_ip_2 = r53_conn.get_record(zone_name, zone_id, master2, 'A')
-    fqdn1 = "{0}.{1}".format(master1, zone_name)
-    fqdn2 = "{0}.{1}".format(master2, zone_name)
-    r53_conn.update_dns_record(zone_id, fqdn1, 'A', master_ip_2)
-    r53_conn.update_dns_record(zone_id, fqdn2, 'A', master_ip_1)
-    local('ssh-keygen -R {0}'.format(fqdn1))
-    local('ssh-keygen -R {0}'.format(fqdn2))
-
-
-def find_master():
-    """
-    Find and return the FQDN of the salt master
-
-    Search for the salt masters zone within the project config
-    file, and then AWS if necessary, returning the fully
-    qualified domain name of the salt master
-    """
-    _validate_fabric_env()
-    project_config = config.ProjectConfig(env.config,
-                                          env.environment,
-                                          env.stack_passwords)
-    cfg = project_config.config
-    try:
-        zone_name = cfg['master_zone']
-    except KeyError:
-        logging.warn("master_zone not found in config file, "
-                     "so DNS discovery of master not possible, "
-                     "falling back to AWS EC2 API.")
-        return get_master_ip()
-    if not hasattr(env, 'tag'):
-        env.tag = 'active'
-    try:
-        master = 'master.{0}.{1}.{2}.{3}'.format(env.tag,
-                                                 env.environment,
-                                                 env.application,
-                                                 zone_name)
-        dns.resolver.query(master, 'A')
-    except dns.resolver.NXDOMAIN:
-        master = 'master.{0}.{1}.{2}'.format(env.environment,
-                                             env.application,
-                                             zone_name)
-    return master
-
-
-def set_master_dns():
-    master_ip = get_master_ip()
-    project_config = config.ProjectConfig(env.config,
-                                          env.environment,
-                                          env.stack_passwords)
-    cfg = project_config.config
-    try:
-        zone_name = cfg['master_zone']
-    except KeyError:
-        logging.warn("master_zone not found in config file, "
-                     "no DNS entry will be created, you will "
-                     "need AWS access to deploy etc.")
-        return False
-    r53 = get_connection(R53)
-    zone_id = r53.get_hosted_zone_id(zone_name)
-    if hasattr(env, 'tag'):
-        dns_name = 'master.{0}.{1}.{2}.{3}'.format(env.tag,
-                                                   env.environment,
-                                                   env.application,
-                                                   zone_name)
-    else:
-        dns_name = 'master.{0}.{1}.{2}'.format(env.environment,
-                                               env.application,
-                                               zone_name)
-    r53.update_dns_record(zone_id, dns_name, 'A', master_ip)
-    return True
-
-
-def put_util_script():
-    # copy the salt_utils.py from local to EC2 and chmod it
-    d = os.path.dirname(__file__)
-    saltutils = d + "/salt_utils.py"
-    if not os.path.isfile(saltutils):
-        print "ERROR: Cannot find %s" % saltutils
-        sys.exit(1)
-    put(saltutils, '/usr/local/bin', use_sudo=True)
-    sudo('chmod 755 /usr/local/bin/salt_utils.py')
-
-
-def install_minions(salt_version):
-    _validate_fabric_env()
-    stack_name = get_stack_name()
-    ec2 = get_connection(EC2)
-    print "Waiting for SSH on all instances..."
-    ec2.wait_for_ssh(stack_name)
-
-    master_inst = ec2.get_master_instance(stack_name)
-    master_public_ip = master_inst.ip_address
-    master_prv_ip = master_inst.private_ip_address
-
-    to_install = ec2.get_unconfigured_minions(stack_name, master_prv_ip)
-
-    if not to_install:
-        return
-
-    sha = '6080a18e6c7c2d49335978fa69fa63645b45bc2a'
-    for instance in to_install:
-
-        env.host_string = 'ubuntu@%s' % instance.ip_address
-
-        put_util_script()
-        run('wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/%s/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh' % sha)
-        sudo('chmod 755 /tmp/bootstrap-salt.sh')
-        sudo('/tmp/bootstrap-salt.sh -A {0} -p python-boto git '
-             '{1}'.format(master_prv_ip, salt_version))
-        env.host_string = 'ubuntu@%s' % master_public_ip
-        sudo('salt-key -y -A')
-
-        # Once we've installed, then set the tag so we don't install again
-        ec2.set_instance_tags([instance.id], {'SaltMasterPrvIP': master_prv_ip})
-
-
-def install_master(salt_version):
-    _validate_fabric_env()
-    stack_name = get_stack_name()
-    ec2 = get_connection(EC2)
-    cfn = get_connection(Cloudformation)
-    print "Waiting for SSH on all instances..."
-    ec2.wait_for_ssh(stack_name)
-
-    master_inst = ec2.get_master_instance(stack_name)
-    if master_inst:
-        master = master_inst.id
-    else:
-        instance_ids = cfn.get_stack_instance_ids(stack_name)
-        master = random.choice(instance_ids)
-
-    master_prv_ip = ec2.get_instance_private_ips([master])[0]
-    master_public_ip = ec2.get_instance_public_ips([master])[0]
-    ec2.set_instance_tags(master, {'SaltMaster': 'True', 'SaltMasterPrvIP': master_prv_ip})
-    set_master_dns()
-
-    env.host_string = 'ubuntu@%s' % master_public_ip
-    sha = '6080a18e6c7c2d49335978fa69fa63645b45bc2a'
-    put_util_script()
-    run('wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/%s/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh' % sha)
-    sudo('chmod 755 /tmp/bootstrap-salt.sh')
-    sudo('/tmp/bootstrap-salt.sh -M -A {0} -p python-boto git '
-         '{1}'.format(master_prv_ip, salt_version))
-    sudo('salt-key -y -A')
-
-
-@task
-def rsync():
-    """
-    Upload the salt data directories to the salt master
-
-    Find the salt master, then upload the salt root directory,
-    the pillar data, and the vendor formulas directory setup
-    by salt-shaker.
+    Get encrypted key from one of the stack hosts,
+    Create tar file with salt states, pillar, formula etc.
+    Encrypt tar using KMS and GPG(AES).
+    Upload tar to S3.
     """
     _validate_fabric_env()
     stack_name = get_stack_name()
+
     work_dir = os.path.dirname(env.real_fabfile)
+
     project_config = config.ProjectConfig(env.config,
                                           env.environment,
                                           env.stack_passwords)
@@ -332,6 +227,7 @@ def rsync():
     local_pillar_dir = os.path.join(
         work_dir,
         salt_cfg.get('local_pillar_dir', 'pillar'),
+        env.environment,
         '.')
     local_vendor_dir = os.path.join(
         work_dir,
@@ -343,18 +239,23 @@ def rsync():
 
     vendor_root = os.path.join(local_vendor_dir, '_root', '.')
     bs_path = os.path.dirname(pkgutil.get_loader('bootstrap_salt').filename)
-    dirs = {local_salt_dir:[remote_state_dir],
-            local_pillar_dir:[remote_pillar_dir],
-            vendor_root:[remote_state_dir, '/srv/formula-repos'],
+    dirs = {local_salt_dir: [remote_state_dir],
+            local_pillar_dir: [remote_pillar_dir],
+            vendor_root: [remote_state_dir, '/srv/formula-repos'],
             '{0}/contrib/etc/salt'.format(bs_path): ['/etc'],
             '{0}/bootstrap_salt/salt_utils.py'.format(bs_path):
-            ['/usr/local/bin/']}
-    tmp_folder = mkdtemp()
+            ['/usr/local/bin/']
+            }
+    tmp_folder = tempfile.mkdtemp()
     for local_dir, dest_dirs in dirs.items():
         for dest_dir in dest_dirs:
             dest = os.path.join(tmp_folder, ".{0}".format(dest_dir))
             local("mkdir -p {0}".format(dest))
             local("cp -r {0} {1}".format(local_dir, dest))
+    cfg_path = os.path.join(tmp_folder, "./{0}".format(remote_pillar_dir))
+    with open(os.path.join(cfg_path, 'cloudformation.sls'), 'w') as cfg_file:
+        yaml.dump(cfg, cfg_file)
+    local("chmod -R 755 {0}".format(tmp_folder))
     local("tar -czvf ./srv.tar -C {0} .".format(tmp_folder))
     local("rm -rf {0}".format(tmp_folder))
 
@@ -373,15 +274,20 @@ def rsync():
 
 @task
 def encrypt_file(file_name):
-    try:
-        with open('./s3-secrets-key.yaml') as f:
-            key = yaml.load(f)['key']
-    except IOError:
-        with open('./s3-secrets-key.yaml', 'w') as f:
-            key = ''.join(random.SystemRandom().choice(string.ascii_uppercase +
-                string.digits) for _ in range(64))
-            yaml.dump({'key': key}, f)
-    local('gpg --yes --output {1}.gpg --passphrase {0} --symmetric {1}'.format(key, file_name))
+    """
+    Encrypt a file using an encrypted KMS data key using GPG with an AES256
+    cipher. Output file_name.gpg
+
+    Args:
+        file_name(string): path of file to encrypt
+    """
+    kms = get_connection(KMS)
+    key = kms.decrypt(open('./salt.key.enc').read())['Plaintext']
+    key = base64.b64encode(key)
+    gpg = gnupg.GPG()
+    gpg.encrypt(open(file_name), passphrase=key, encrypt=False, symmetric='AES256',
+                output=open('{0}.gpg'.format(file_name), 'w'))
+
 
 @task(alias='ssh_keys')
 def generate_ssh_key_pillar(force=False, strict=True):

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -4,8 +4,11 @@ import os
 from StringIO import StringIO
 import sys
 import random
+import string
 import yaml
+from tempfile import mkdtemp
 import logging
+import pkgutil
 logging.basicConfig(level=logging.INFO)
 
 import bootstrap_cfn.config as config
@@ -18,6 +21,7 @@ from bootstrap_cfn.fab_tasks import _validate_fabric_env, \
 from cloudformation import Cloudformation
 from ec2 import EC2
 from bootstrap_cfn.r53 import R53
+import bootstrap_salt
 
 from .deploy_lib import github
 
@@ -115,6 +119,10 @@ def get_connection(klass):
     _validate_fabric_env()
     return klass(env.aws, env.aws_region)
 
+@task
+def mmb1():
+    stack_name = get_stack_name()
+    print stack_name
 
 def get_master_ip():
     _validate_fabric_env()
@@ -304,6 +312,7 @@ def rsync():
     by salt-shaker.
     """
     _validate_fabric_env()
+    stack_name = get_stack_name()
     work_dir = os.path.dirname(env.real_fabfile)
     project_config = config.ProjectConfig(env.config,
                                           env.environment,
@@ -328,35 +337,47 @@ def rsync():
     remote_state_dir = salt_cfg.get('remote_state_dir', '/srv/salt')
     remote_pillar_dir = salt_cfg.get('remote_pillar_dir', '/srv/pillar')
 
-    master_ip = find_master()
-    env.host_string = '{0}@{1}'.format(env.user, master_ip)
-    put_util_script()
-    sudo('mkdir -p {0}'.format(remote_state_dir))
-    sudo('mkdir -p {0}'.format(remote_pillar_dir))
-    upload_project(
-        remote_dir=remote_state_dir,
-        local_dir=os.path.join(local_vendor_dir, '_root', '.'),
-        use_sudo=True)
-    upload_project(
-        remote_dir='/srv/',
-        local_dir=os.path.join(local_vendor_dir, 'formula-repos'),
-        use_sudo=True)
-    upload_project(
-        remote_dir=remote_state_dir,
-        local_dir=local_salt_dir,
-        use_sudo=True)
-    upload_project(
-        remote_dir=remote_pillar_dir,
-        local_dir=os.path.join(local_pillar_dir, env.environment, '.'),
-        use_sudo=True)
-    cf_sls = StringIO(yaml.dump(cfg))
-    put(
-        remote_path=os.path.join(
-            remote_pillar_dir,
-            'cloudformation.sls'),
-        local_path=cf_sls,
-        use_sudo=True)
+    vendor_root = os.path.join(local_vendor_dir, '_root', '.')
+    bs_path = os.path.dirname(pkgutil.get_loader('bootstrap_salt').filename)
+    dirs = {local_salt_dir:[remote_state_dir],
+            local_pillar_dir:[remote_pillar_dir],
+            vendor_root:[remote_state_dir, '/srv/formula-repos'],
+            '{0}/contrib/etc/salt'.format(bs_path): ['/etc'],
+            '{0}/bootstrap_salt/salt_utils.py'.format(bs_path):
+            ['/usr/local/bin/']}
+    tmp_folder = mkdtemp()
+    for local_dir, dest_dirs in dirs.items():
+        for dest_dir in dest_dirs:
+            dest = os.path.join(tmp_folder, ".{0}".format(dest_dir))
+            local("mkdir -p {0}".format(dest))
+            local("cp -r {0} {1}".format(local_dir, dest))
+    local("tar -czvf ./srv.tar -C {0} .".format(tmp_folder))
+    local("rm -rf {0}".format(tmp_folder))
 
+    env.host_string = '{0}@{1}'.format(env.user, get_instance_ips()[0])
+    # Here we get the encypted data key for this specific stack, we then use
+    # KMS to get the plaintext key and use that key to encrypt the salt content
+    # We get the key over SSH because it is unique to each stack.
+    get(remote_path='/etc/salt.key.enc', local_path='./', use_sudo=True)
+    encrypt_file('./srv.tar')
+    local("rm ./salt.key.enc")
+
+    local("rm -rf ./srv.tar")
+    local("aws s3 --profile {0} cp ./srv.tar.gpg s3://{1}-salt/".format(env.aws,
+          stack_name))
+    local("rm -rf ./srv.tar.gpg")
+
+@task
+def encrypt_file(file_name):
+    try:
+        with open('./s3-secrets-key.yaml') as f:
+            key = yaml.load(f)['key']
+    except IOError:
+        with open('./s3-secrets-key.yaml', 'w') as f:
+            key = ''.join(random.SystemRandom().choice(string.ascii_uppercase +
+                string.digits) for _ in range(64))
+            yaml.dump({'key': key}, f)
+    local('gpg --yes --output {1}.gpg --passphrase {0} --symmetric {1}'.format(key, file_name))
 
 @task(alias='ssh_keys')
 def generate_ssh_key_pillar(force=False, strict=True):

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -22,6 +22,7 @@ from cloudformation import Cloudformation
 from ec2 import EC2
 from bootstrap_cfn.r53 import R53
 import bootstrap_salt
+from bootstrap_salt.config import MyConfigParser
 
 from .deploy_lib import github
 
@@ -35,8 +36,11 @@ RETRY_INTERVAL = 10
 path = env.real_fabfile or os.getcwd()
 sys.path.append(os.path.dirname(path))
 
-
 env.stack = None
+# This overrides the config parser in bootstrap-cfn
+# this allows us to inject extra userdata into the launch
+# config of the auto scaling groups
+env.cloudformation_parser = MyConfigParser
 
 
 @task

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -258,6 +258,7 @@ def upload_salt():
     dirs = {local_salt_dir: [remote_state_dir],
             local_pillar_dir: [remote_pillar_dir],
             vendor_root: [remote_state_dir, '/srv/formula-repos'],
+            '{0}/contrib/srv/salt/_grains'.format(bs_path): [remote_state_dir],
             '{0}/contrib/etc/salt'.format(bs_path): ['/etc'],
             '{0}/bootstrap_salt/salt_utils.py'.format(bs_path):
             ['/usr/local/bin/']
@@ -272,6 +273,8 @@ def upload_salt():
     with open(os.path.join(cfg_path, 'cloudformation.sls'), 'w') as cfg_file:
         yaml.dump(cfg, cfg_file)
     local("chmod -R 755 {0}".format(tmp_folder))
+    local("chmod -R 700 {0}{1}".format(tmp_folder, remote_state_dir))
+    local("chmod -R 700 {0}{1}".format(tmp_folder, remote_pillar_dir))
     local("tar -czvf ./srv.tar -C {0} .".format(tmp_folder))
     local("rm -rf {0}".format(tmp_folder))
 
@@ -287,6 +290,7 @@ def upload_salt():
     local("aws s3 --profile {0} cp ./srv.tar.gpg s3://{1}-salt/".format(env.aws,
           stack_name))
     local("rm -rf ./srv.tar.gpg")
+
 
 @task
 def encrypt_file(file_name):

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import math
 import os
 import sys
 import yaml
@@ -151,6 +152,22 @@ def get_instance_ips():
     ec2 = get_connection(EC2)
     stack_name = get_stack_name()
     return ec2.get_stack_instance_public_ips(stack_name)
+
+
+def get_ips_batch(fraction=None):
+    '''
+    Takes a list of ips and batches them
+    in the format [['ip1','ip2']]
+    If a fraction is specified the ips are split into batches sized by
+    that fraction i.e. 4 ips with fraction=0.5 will return:
+    [['ip1', 'ip2'],['ip3','ip4']]
+    '''
+    ips = get_instance_ips()
+    if fraction:
+        number_in_batch = int(math.ceil(len(ips)*float(fraction)))
+        return [ips[i:i+number_in_batch] for i in xrange(0, len(ips), number_in_batch)]
+    else:
+        return [ips]
 
 
 @task

--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
-import salt
-import salt.runner
-import salt.config
-import salt.client
-import salt.output
-import time
+import base64
+import logging
+import subprocess
 import sys
-import math
+
+import salt
+import salt.client
+import salt.config
+import salt.output
+import salt.runner
+logging.basicConfig(level=logging.ERROR)
 
 
 class BootstrapUtilError(Exception):
@@ -23,144 +26,51 @@ class SaltParserError(BootstrapUtilError):
     pass
 
 
-class UtilTimeoutError(BootstrapUtilError):
-    pass
+def get_salt_data():
+    import boto.s3
+    import boto.kms
+    import gnupg
+    caller = salt.client.Caller()
+    stack_name = caller.function('grains.item', 'aws:cloudformation:stack-name')['aws:cloudformation:stack-name']
+    region = caller.function('grains.item', 'aws_region')['aws_region']
+    kms = boto.kms.connect_to_region(region)
+    s3 = boto.s3.connect_to_region(region)
+    tar_file = s3.get_bucket('{0}-salt'.format(stack_name)).get_key('srv.tar.gpg')
+    if not tar_file:
+        sys.exit(0)
+    tar_file.get_contents_to_filename('/srv.tar.gpg')
+    key = kms.decrypt(open('/etc/salt.key.enc').read())['Plaintext']
+    key = base64.b64encode(key)
+    gpg = gnupg.GPG()
+    gpg.decrypt_file(open('/srv.tar.gpg'), passphrase=key,
+                     output='/srv.tar')
+    subprocess.call(['tar', '--no-same-owner', '-xvf', '/srv.tar', '-C', '/'])
 
 
-def do_nothing(*args, **kwargs):
-    pass
-
-
-def get_minions_batch(target, fraction=None):
+def highstate():
     '''
-    Takes a salt glob target and returns batches of minion ids that match
-    in the format [['minion1','minion2']]
-    If a fraction is specified the minions are split into batches sized by
-    that fraction i.e. 4 minions with fraction=0.5 will return:
-    [['minion1', 'minion2'],['minion3','minion4']]
-    '''
-    local = salt.client.LocalClient()
-    minions = local.cmd(target, 'test.ping').keys()
-    if fraction:
-        number_in_batch = int(math.ceil(len(minions)*float(fraction)))
-        return [minions[i:i+number_in_batch] for i in xrange(0, len(minions), number_in_batch)]
-    else:
-        return [minions]
-
-
-def do_timeout(timeout, interval):
-
-    def decorate(func):
-
-        def wrapper(*args, **kwargs):
-            attempts = 0
-            while True:
-                result = func(*args, **kwargs)
-                if result:
-                    return result
-                if attempts >= timeout / interval:
-                    raise UtilTimeoutError("Timeout in {0}".format(func.__name__))
-                attempts += 1
-                time.sleep(interval)
-        return wrapper
-    return decorate
-
-
-def start_highstate(target, expr_form='list'):
-    '''
-    Starts a highstate job returns the job id
-    Args:
-        target(string): minion target string
-        expr_form(string): salt minion target format e.g. list, glob etc.
-    '''
-    local = salt.client.LocalClient()
-    jid = local.cmd_async(target, 'state.highstate', expr_form=expr_form)
-    return jid
-
-
-def start_state(target, state, expr_form='list'):
-    '''
-    Starts a given state job returns the job id
-    Args:
-        target(string): minion target string
-        state(string): the state to run
-        expr_form(string): salt minion target format e.g. list, glob etc.
-    '''
-    local = salt.client.LocalClient()
-    jid = local.cmd_async(target, 'state.sls', [state], expr_form=expr_form)
-    return jid
-
-
-def state_result(jid):
-    '''
-    Get the result of a given salt job id, return the results dictionary.
-    Args:
-        jid(int): salt job id
-    '''
-    opts = salt.config.master_config('/etc/salt/master')
-    # This is added because salt 2014.7 no longer prints all the output from
-    # a highstate when you lookup the jid. Instead we print the output ourselves
-    # when we check the result and overwrite the salt outputter here to do
-    # nothing.
-    d_o = salt.output.display_output
-    salt.output.display_output = do_nothing
-    r = salt.runner.RunnerClient(opts)
-    result = r.cmd('jobs.lookup_jid', [jid])
-    salt.output.display_output = d_o
-    if result:
-        return result
-    return False
-
-
-def highstate(target, fraction, timeout, interval):
-    '''
-    Starts a highstate, blocks until all results have been checked. Returns True
-    or raises one of the following.
     Raises:
         SaltParserError: if any minion cannot execute the state
         SaltStateError: if any state execution returns False
-        UtilTimeoutError: if the job does not finish in the given timeout
-    Args:
-        target(string): minion target string
-        fraction(float): the decimal fraction of minions to target in each batch
-        timeout(int): the number of seconds to wait for the highstate to finish
-            on all minions
-        interval(int): the number of seconds to wait between checking if the job
-            has finished
     '''
-    results = []
-    for b in get_minions_batch(target, fraction):
-        jid = start_highstate(','.join(b), expr_form='list')
-        res = do_timeout(timeout, interval)(state_result)(jid)
-        results.append(check_state_result(res))
-        print "Minions {0} complete".format(b)
-    return all(results)
+    get_salt_data()
+    caller = salt.client.Caller()
+    res = caller.function('state.highstate')
+    return check_state_result(res)
 
 
-def state(target, state, fraction, timeout, interval):
+def state(state):
     '''
-    Starts a state, blocks until all results have been checked. Returns True
-    or raises one of the following.
     Raises:
         SaltParserError: if any minion cannot execute the state
         SaltStateError: if any state execution returns False
-        UtilTimeoutError: if the job does not finish in the given timeout
     Args:
-        target(string): minion target string
-        fraction(float): the decimal fraction of minions to target in each batch
         state(string): the state to run
-        timeout(int): the number of seconds to wait for the highstate to finish
-            on all minions
-        interval(int): the number of seconds to wait between checking if the job
-            has finished
     '''
-    results = []
-    for b in get_minions_batch(target, fraction):
-        jid = start_state(','.join(b), state, expr_form='list')
-        res = do_timeout(timeout, interval)(state_result)(jid)
-        results.append(check_state_result(res))
-        print "Minions {0} complete".format(b)
-    return all(results)
+    get_salt_data()
+    caller = salt.client.Caller()
+    res = caller.function('state.sls', state)
+    return check_state_result(res)
 
 
 def check_state_result(result):
@@ -173,14 +83,12 @@ def check_state_result(result):
     Args:
         result(dict): salt results dictionary
     '''
-    results = []
-    __opts__ = salt.config.master_config('/etc/salt/master')
-    for minion, ret in result.items():
-        salt.output.display_output({minion: ret}, out='highstate', opts=__opts__)
-        if isinstance(ret, dict):
-            results += [v['result'] for v in ret.values()]
-        else:
-            raise SaltParserError('Minion could not parse state data')
+    __opts__ = salt.config.minion_config('/etc/salt/minion')
+    salt.output.display_output({'local': result}, out='highstate', opts=__opts__)
+    if isinstance(result, dict):
+        results = [v['result'] for v in result.values()]
+    else:
+        raise SaltParserError('Minion could not parse state data')
     if all(results):
         return True
     else:
@@ -189,23 +97,11 @@ def check_state_result(result):
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='Run salt states')
-    parser.add_argument('-t', dest='target', type=str,
-                        help='target', required=True)
-    parser.add_argument('-f', dest='fraction', type=float,
-                        help='for zero downtime deploy, decimal fraction of'
-                        'minions to deploy to at one time.', required=False,
-                        default=None)
     parser.add_argument('-s', dest='state', type=str,
                         help='Name of state or "highstate"', required=True)
-    parser.add_argument('-T', dest='timeout', type=float,
-                        help='Timeout to wait for state execution to finish'
-                        'on all minions.', required=False, default=1800)
-    parser.add_argument('-I', dest='interval', type=float,
-                        help='Interval to check for finished execution.',
-                        required=False, default=10)
 
     args = parser.parse_args()
     if args.state == "highstate":
-        highstate(args.target, args.fraction, args.timeout, args.interval)
+        highstate()
     else:
-        state(args.target, args.state, args.fraction, args.timeout, args.interval)
+        state(args.target, args.state)

--- a/contrib/bootstrap.sh
+++ b/contrib/bootstrap.sh
@@ -7,7 +7,7 @@ pip install gnupg
 cd /tmp
 git clone https://github.com/ministryofjustice/bootstrap-salt.git
 cd ./bootstrap-salt
-git checkout $BOOTSTRAP_SALT_REV
+git checkout remove-salt-master
 cp -Lrf ./contrib/* /
 /tmp/bootstrap-salt.sh git v2014.7.5
 salt-call saltutil.sync_all

--- a/contrib/bootstrap.sh
+++ b/contrib/bootstrap.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/6080a18e6c7c2d49335978fa69fa63645b45bc2a/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh
+chmod 700 /tmp/bootstrap-salt.sh
+apt-get update && apt-get -y install python-pip git python-dev
+pip install boto
+pip install gnupg
+cd /tmp
+git clone https://github.com/ministryofjustice/bootstrap-salt.git
+cd ./bootstrap-salt
+git checkout $BOOTSTRAP_SALT_REV
+cp -Lrf ./contrib/* /
+/tmp/bootstrap-salt.sh git v2014.7.5
+salt-call saltutil.sync_all
+/usr/local/bin/salt_utils.py -s highstate
+touch /tmp/bootstrap_done

--- a/contrib/bootstrap.sh
+++ b/contrib/bootstrap.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
+REVISION=$1
 wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/6080a18e6c7c2d49335978fa69fa63645b45bc2a/bootstrap-salt.sh -O /tmp/bootstrap-salt.sh
 chmod 700 /tmp/bootstrap-salt.sh
 apt-get update && apt-get -y install python-pip git python-dev
 pip install boto
 pip install gnupg
 cd /tmp
-git clone https://github.com/ministryofjustice/bootstrap-salt.git
+git clone --depth 1 --branch $REVISION https://github.com/ministryofjustice/bootstrap-salt.git
 cd ./bootstrap-salt
-git checkout remove-salt-master
 cp -Lrf ./contrib/* /
 /tmp/bootstrap-salt.sh git v2014.7.5
 salt-call saltutil.sync_all

--- a/contrib/etc/salt/minion
+++ b/contrib/etc/salt/minion
@@ -1,0 +1,1 @@
+file_client: local

--- a/contrib/srv/salt/_grains/tags_to_grains.py
+++ b/contrib/srv/salt/_grains/tags_to_grains.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+import random
+import sys
+import time
+import urllib2
+
+import boto.cloudformation
+import boto.ec2
+from boto.exception import BotoServerError
+
+
+def get_aws_metadata():
+    metadata_ip = '169.254.169.254'
+    try:
+        instance_id = urllib2.urlopen(
+            'http://{0}/latest/meta-data/instance-id'.format(metadata_ip)).read().strip()
+        region = urllib2.urlopen(
+            'http://{0}/latest/meta-data/placement/availability-zone'.format(metadata_ip)).read().strip()[:-1]
+        return {'aws_instance_id': instance_id, 'aws_region': region}
+    except Exception as err:
+        sys.stderr.write('tags_to_grains ERROR: %s\n' % str(err))
+        return {'custom_grain_error': True}
+
+
+def get_cf_data(attempt=0):
+    try:
+        md = get_aws_metadata()
+        conn = boto.cloudformation.connect_to_region(md['aws_region'])
+        tags = get_ec2_data()
+        stack_name = tags['aws:cloudformation:stack-name']
+        stack_outputs = conn.describe_stacks(stack_name)[0].outputs
+        out = {}
+        [out.update({o.key: o.value}) for o in stack_outputs]
+        return out
+    except BotoServerError:
+        if attempt > 5:
+            return {'custom_grain_error': True}
+        time.sleep(random.randint(1, 5))
+        attempt = attempt + 1
+        return get_cf_data(attempt)
+    except Exception as err:
+        sys.stderr.write('tags_to_grains ERROR: %s\n' % str(err))
+        return {'custom_grain_error': True}
+
+
+def get_ec2_data(attempt=0):
+    """
+    This retrieves ec2 data for the instance e.g
+    Project: courtfinder
+    Role: docker
+    Apps: search,admin
+    Env: dev
+
+    To transform this data into salt grains run:
+    ``salt '*' saltutil.sync_all``
+    """
+
+    try:
+        md = get_aws_metadata()
+        conn = boto.ec2.connect_to_region(md['aws_region'])
+        instance = conn.get_all_instances(
+            instance_ids=[md['aws_instance_id']])[0].instances[0]
+        return instance.tags
+    except BotoServerError:
+        if attempt > 5:
+            return {'custom_grain_error': True}
+        time.sleep(random.randint(1, 5))
+        attempt = attempt + 1
+        return get_ec2_data(attempt)
+    except Exception as err:
+        sys.stderr.write('tags_to_grains ERROR: %s\n' % str(err))
+        return {'custom_grain_error': True}
+
+if __name__ == '__main__':
+    print get_ec2_data()
+    print get_cf_data()
+    print get_aws_metadata()

--- a/contrib/usr/local/bin/salt_utils.py
+++ b/contrib/usr/local/bin/salt_utils.py
@@ -1,0 +1,1 @@
+../../../../bootstrap_salt/salt_utils.py

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         'bootstrap-cfn>=0.5.1',
         'requests',
         'ndg-httpsclient',
-        'dnspython'
+        'dnspython',
+        'gnupg'
     ],
     setup_requires=[
         'mock>=1.0.1',

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'requests',
         'ndg-httpsclient',
         'dnspython',
+        'awscli',
         'gnupg'
     ],
     setup_requires=[

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+import json
+import pkg_resources
 import unittest
 
 import bootstrap_salt.config
@@ -29,8 +31,10 @@ class TestConfig(unittest.TestCase):
     def test_get_ec2_userdata(self, mock_env, mock_super):
         mock_super.return_value = []
         mock_env.kms_data_key = 'fake-key-data'
+        version = pkg_resources.get_distribution("bootstrap_salt").version
 
-        expected = [{'content': 'runcmd: [/tmp/bootstrap.sh vmmb]\n', 'mime_type': 'text/cloud-config'},
+        expected = [{'content': 'runcmd: [/tmp/bootstrap.sh v{0}]\n'.format(version),
+                     'mime_type': 'text/cloud-config'},
                     {'content': "write_files:\n- {content: fake-key-data, encoding: b64, owner: 'root:root', path: /etc/salt.key.enc,\n  permissions: '0600'}\n- {content: '#!/bin/bash\n\n    REVISION=$1\n\n    wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/6080a18e6c7c2d49335978fa69fa63645b45bc2a/bootstrap-salt.sh\n    -O /tmp/bootstrap-salt.sh\n\n    chmod 700 /tmp/bootstrap-salt.sh\n\n    apt-get update && apt-get -y install python-pip git python-dev\n\n    pip install boto\n\n    pip install gnupg\n\n    cd /tmp\n\n    git clone --depth 1 --branch $REVISION https://github.com/ministryofjustice/bootstrap-salt.git\n\n    cd ./bootstrap-salt\n\n    cp -Lrf ./contrib/* /\n\n    /tmp/bootstrap-salt.sh git v2014.7.5\n\n    salt-call saltutil.sync_all\n\n    /usr/local/bin/salt_utils.py -s highstate\n\n    touch /tmp/bootstrap_done\n\n    ', owner: 'root:root', path: /tmp/bootstrap.sh, permissions: '0700'}\n", 'mime_type': 'text/cloud-config'}]  # NOQA
 
         x = MyConfigParser({}, 'my-stack').get_ec2_userdata()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,40 @@
+import unittest
+
+import bootstrap_salt.config
+from bootstrap_salt.config import MyConfigParser
+
+from mock import patch
+
+from testfixtures import compare
+from troposphere import Template
+
+
+class TestConfig(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    # http://mock.readthedocs.org/en/latest/patch.html#where-to-patch
+    @patch('bootstrap_salt.config.ConfigParser.base_template')
+    @patch.object(bootstrap_salt.config, 'env')
+    def test_base_template(self, mock_env, mock_super):
+        mock_super.return_value = Template()
+        mock_env.kms_key_id = 'fake-key-id'
+        x = MyConfigParser({}, 'my-stack').base_template()
+        compare(x.mappings['KMS'], {'salt': {'key': 'fake-key-id'}})
+
+    # http://mock.readthedocs.org/en/latest/patch.html#where-to-patch
+    @patch('bootstrap_salt.config.ConfigParser.get_ec2_userdata')
+    @patch.object(bootstrap_salt.config, 'env')
+    def test_get_ec2_userdata(self, mock_env, mock_super):
+        mock_super.return_value = []
+        mock_env.kms_data_key = 'fake-key-data'
+
+        expected = [{'content': 'runcmd: [/tmp/bootstrap.sh vmmb]\n', 'mime_type': 'text/cloud-config'},
+                    {'content': "write_files:\n- {content: fake-key-data, encoding: b64, owner: 'root:root', path: /etc/salt.key.enc,\n  permissions: '0600'}\n- {content: '#!/bin/bash\n\n    REVISION=$1\n\n    wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/6080a18e6c7c2d49335978fa69fa63645b45bc2a/bootstrap-salt.sh\n    -O /tmp/bootstrap-salt.sh\n\n    chmod 700 /tmp/bootstrap-salt.sh\n\n    apt-get update && apt-get -y install python-pip git python-dev\n\n    pip install boto\n\n    pip install gnupg\n\n    cd /tmp\n\n    git clone --depth 1 --branch $REVISION https://github.com/ministryofjustice/bootstrap-salt.git\n\n    cd ./bootstrap-salt\n\n    cp -Lrf ./contrib/* /\n\n    /tmp/bootstrap-salt.sh git v2014.7.5\n\n    salt-call saltutil.sync_all\n\n    /usr/local/bin/salt_utils.py -s highstate\n\n    touch /tmp/bootstrap_done\n\n    ', owner: 'root:root', path: /tmp/bootstrap.sh, permissions: '0700'}\n", 'mime_type': 'text/cloud-config'}]  # NOQA
+
+        x = MyConfigParser({}, 'my-stack').get_ec2_userdata()
+        compare(x, expected)
+
+    def tearDown(self):
+        pass

--- a/tests/test_fab_tasks.py
+++ b/tests/test_fab_tasks.py
@@ -1,0 +1,38 @@
+import unittest
+
+from mock import patch
+
+from testfixtures import compare
+
+from bootstrap_salt import fab_tasks
+
+
+class TestFabTasks(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_get_ips_batch(self):
+        # Test one batch
+        mock_ret = ['1.1.1.1', '2.2.2.2']
+        with patch.object(fab_tasks, 'get_instance_ips', return_value=mock_ret):
+            expected = [['1.1.1.1', '2.2.2.2']]
+            x = fab_tasks.get_ips_batch()
+            compare(x, expected)
+        # Test 50% batch
+        mock_ret = ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4']
+        with patch.object(fab_tasks, 'get_instance_ips', return_value=mock_ret):
+            expected = [['1.1.1.1', '2.2.2.2'],
+                        ['3.3.3.3', '4.4.4.4']]
+            x = fab_tasks.get_ips_batch(0.5)
+            compare(x, expected)
+        # 50% batch uneven nodes
+        mock_ret = ['1.1.1.1', '2.2.2.2', '3.3.3.3']
+        with patch.object(fab_tasks, 'get_instance_ips', return_value=mock_ret):
+            expected = [['1.1.1.1', '2.2.2.2'],
+                        ['3.3.3.3']]
+            x = fab_tasks.get_ips_batch(0.5)
+            compare(x, expected)
+
+    def tearDown(self):
+        pass

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -1,0 +1,56 @@
+import base64
+import unittest
+
+from bootstrap_salt.kms import KMS
+
+import boto.kms
+
+import mock
+
+from mock import patch
+
+from testfixtures import compare
+
+
+class TestKMS(unittest.TestCase):
+
+    def setUp(self):
+        self.env = mock.Mock()
+        self.env.aws = 'dev'
+        self.env.aws_profile = 'the-profile-name'
+        kms_mock = mock.Mock()
+        kms_connect_result = mock.Mock(name='cf_connect')
+        kms_mock.return_value = kms_connect_result
+        boto.kms.connect_to_region = kms_mock
+        self.k = KMS(self.env.aws_profile)
+
+    def test_get_key_id(self):
+        mock_ret = {'Aliases': [{'TargetKeyId': 'mock-key-id',
+                                 'AliasName': 'alias/mock-alias'}]}
+        with patch.object(self.k.conn_kms, 'list_aliases', return_value=mock_ret):
+            ret = self.k.get_key_id('mock-alias')
+            compare(ret, 'mock-key-id')
+
+    def test_create_key(self):
+        mock_ret = {'KeyMetadata': {'KeyId': 'mock-key-id'}}
+        with patch.object(self.k.conn_kms, 'create_key', return_value=mock_ret):
+            ret = self.k.create_key('mock-alias')
+            self.k.conn_kms.create_alias.assert_called_with('alias/mock-alias', 'mock-key-id')
+            compare(ret, 'mock-key-id')
+
+    def test_generate_data_key(self):
+        mock_ret = {'CiphertextBlob': 'encryptedblob'}
+        expect = base64.b64encode('encryptedblob')
+        with patch.object(self.k.conn_kms,
+                          'generate_data_key',
+                          return_value=mock_ret):
+            ret = self.k.generate_data_key('mock-key-id')
+            compare(ret, expect)
+
+    def test_decrypt(self):
+        with patch.object(self.k.conn_kms, 'decrypt', return_value='mock-ret'):
+            ret = self.k.decrypt('cipherblob')
+            compare(ret, 'mock-ret')
+
+    def tearDown(self):
+        pass

--- a/tests/test_salt_util.py
+++ b/tests/test_salt_util.py
@@ -16,93 +16,36 @@ class SaltUtilTestCase(unittest.TestCase):
     def setUp(self):
         pass
 
-    def test_get_minions_batch(self):
-        mock_result = mock.Mock()
-        # No batch
-        mock_config = {'cmd.return_value': {'minion1': 'blah',
-                                            'minion2': 'blah'}}
-        mock_result.configure_mock(**mock_config)
-        mock_client = mock.Mock()
-        mock_client.return_value = mock_result
-        mock_c = mock.Mock(LocalClient=mock_client)
-        salt.client = mock_c
-        x = salt_utils.get_minions_batch('*')
-        expected = [['minion1', 'minion2']]
-        self.assertEqual(x, expected)
-
-        # 50% batch
-        mock_config = {'cmd.return_value': {'minion1': 'blah',
-                                            'minion2': 'blah',
-                                            'minion3': 'blah',
-                                            'minion4': 'blah'}}
-        mock_result.configure_mock(**mock_config)
-        mock_client = mock.Mock()
-        mock_client.return_value = mock_result
-        mock_c = mock.Mock(LocalClient=mock_client)
-        salt.client = mock_c
-
-        x = salt_utils.get_minions_batch('*', 0.5)
-        expected = [['minion4', 'minion1'], ['minion3', 'minion2']]
-        self.assertEqual(x, expected)
-
-        # 50% batch uneven minons
-        mock_config = {'cmd.return_value': {'minion1': 'blah',
-                                            'minion2': 'blah',
-                                            'minion3': 'blah'}}
-        mock_result.configure_mock(**mock_config)
-        mock_client = mock.Mock()
-        mock_client.return_value = mock_result
-        mock_c = mock.Mock(LocalClient=mock_client)
-        salt.client = mock_c
-
-        x = salt_utils.get_minions_batch('*', 0.5)
-        expected = [['minion1', 'minion3'], ['minion2']]
-        self.assertEqual(x, expected)
-
     def test_state_result(self):
         salt.config = mock.Mock()
         mock_result = mock.Mock()
-        mock_config = {'cmd.return_value': {'minon1': {'state': {'result': True}}}}
+        mock_config = {'function.return_value': {'state': {'result': True}}}
         mock_result.configure_mock(**mock_config)
 
         mock_client = mock.Mock()
         mock_client.return_value = mock_result
 
-        mock_runner = mock.Mock(RunnerClient=mock_client)
+        mock_caller = mock.Mock(Caller=mock_client)
 
-        salt.runner = mock_runner
-        x = salt_utils.state_result('12345')
+        salt.client = mock_caller
+        salt_utils.get_salt_data = mock.Mock()
+        x = salt_utils.state('12345')
         self.assertTrue(x)
 
-    def test_no_state_result(self):
-        salt.config = mock.Mock()
-        mock_result = mock.Mock()
-        mock_config = {'cmd.return_value': {}}
-        mock_result.configure_mock(**mock_config)
-
-        mock_client = mock.Mock()
-        mock_client.return_value = mock_result
-
-        mock_runner = mock.Mock(RunnerClient=mock_client)
-
-        salt.runner = mock_runner
-        x = salt_utils.state_result('12345')
-        self.assertFalse(x)
-
     def test_check_state_result_good(self):
-        result = {'minon1': {'state': {'result': True}},
-                  'minion2': {'state': {'result': True}}}
+        result = {'state': {'result': True},
+                  'state1': {'result': True}}
         x = salt_utils.check_state_result(result)
         self.assertTrue(x)
 
     def test_check_state_result_bad(self):
-        result = {'minon1': {'state': {'result': False}},
-                  'minion2': {'state': {'result': True}}}
+        result = {'state': {'result': False},
+                  'state1': {'result': True}}
         with self.assertRaises(salt_utils.SaltStateError):
             salt_utils.check_state_result(result)
 
     def test_check_state_result_parse_error(self):
-        result = {'minon1': ['SOME SALT PARSER ERROR']}
+        result = ['SOME SALT PARSER ERROR']
         with self.assertRaises(salt_utils.SaltParserError):
             salt_utils.check_state_result(result)
 


### PR DESCRIPTION
This is a big change (sorry), it's also going to be non backwards compatible (double sorry)

The idea is to remove the need to run a salt master. This makes it easier to bootstrap salt using launch configuration in EC2. To achieve this:

* Create tar file with salt states, pillar, formula etc.
* We use AWS KMS to encrypt the tar file
* We upload it to S3
* We include a new bootstrap script in the launch config in addition to some KMS data needed to decrypt the tar file.
* The salt utility script now has the ability to pull down and decrypt the content in S3
* The discovery and batching of minions is moved to fabric both here and in template-deploy.