### PR TITLE
(WIP) Automatically remove default users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+##UNRELEASED
+
+* Automatically remove default users
+
 ## Version 0.2.2
 
 * Make it possible to create multiple stacks with the same app and env.

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -5,6 +5,7 @@ from StringIO import StringIO
 import sys
 import random
 import yaml
+import json
 import logging
 logging.basicConfig(level=logging.INFO)
 
@@ -408,3 +409,24 @@ def generate_ssh_key_pillar(force=False, strict=True):
 
     result = {'admins': ssh_key_data}
     yaml.dump(result, open(pillar_file, 'w'), default_flow_style=False)
+
+
+@task
+def check_admins_exist():
+    """
+    Check that we have set some admins in the pillar, exit with error code 1 if not
+
+    Return:
+        bool: True if admins exist in pillar, False otherwise
+    """
+    env.host_string = '{0}@{1}'.format(env.user, find_master())
+    admins_json = sudo('/usr/bin/salt-call pillar.get admins --out=json 2> /dev/null', shell=False)
+    admins_list = json.loads(admins_json).get('local', {}).keys()
+    if not len(admins_list) > 0:
+        link = "https://github.com/ministryofjustice/bootstrap-salt#github-based-ssh-key-generation"
+        logging.error(("check_admins_exist: No admins found in pillar, please create them, see '%s'"
+                       % (link)))
+        return False
+    logging.info(("check_admins_exist: Found admins in pillar, '%s'"
+                  % (', '.join(admins_list))))
+    return True


### PR DESCRIPTION
This change will check that admins have been created in the pillar,
if not, we will not create the stack.

* Added a check_admins_exist function to the fab_tasks
* Added the admins check as a requisite of cfn_create progressing
* Updated changelog