### PR TITLE
Fix running state in salt_utils script

### DIFF
--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -113,4 +113,4 @@ if __name__ == "__main__":
     if args.state == "highstate":
         highstate()
     else:
-        state(args.target, args.state)
+        state(args.state)


### PR DESCRIPTION
Remove target argument, no longer needed for masterless.