### PR TITLE
Make cfn_delete remove the managed tar file so delete compeltes cleanly

### DIFF
--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from functools import wraps
 import math
 import os
 import sys
@@ -134,14 +135,15 @@ bcfn_create = cfn_create
 
 
 @task
-def cfn_create(test=False):
+@wraps(bcfn_create)
+def cfn_create(*args, **kwargs):
     """
     Here we override the cfn_create task from bootstrap_cfn so that we
     can inject the KMS key ID and encrypted key into the fabric environment.
     """
     env.kms_key_id = get_kms_key_id()
     env.kms_data_key = create_kms_data_key()
-    bcfn_create(test=test)
+    bcfn_create(*args, **kwargs)
 
 
 def get_instance_ips():

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -3,6 +3,7 @@
 from functools import wraps
 import math
 import os
+from pipes import quote
 import sys
 import yaml
 import tempfile
@@ -216,6 +217,20 @@ def get_connection(klass):
     """
     _validate_fabric_env()
     return klass(env.aws, env.aws_region)
+
+@task
+def delete_tar():
+    """
+    Remove the encrypted salt tree from the s3 bucket.
+
+    This needs to be called before invoking cfn_delete otherwise the S3 bucket
+    will fail to be deleted. This will only delete the one file the
+    ``upload_salt`` task creates so if any other files are placed in there then
+    this task will still fail.
+    """
+    _validate_fabric_env()
+    stack_name = get_stack_name()
+    local("aws s3 --profile {0} rm s3://{1}-salt/srv.tar.gpg".format(quote(env.aws), quote(stack_name)))
 
 
 @task

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'Fabric>=1.10.1',
         'PyYAML>=3.11',
         'boto>=2.36.0',
-        'bootstrap-cfn>=0.5.1',
+        'bootstrap-cfn>=0.5.7',
         'requests',
         'ndg-httpsclient',
         'dnspython',

--- a/tests/test_fab_tasks.py
+++ b/tests/test_fab_tasks.py
@@ -36,3 +36,14 @@ class TestFabTasks(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    @patch('bootstrap_salt.fab_tasks.bcfn_delete')
+    def test_cfn_delete_wrapper(self, mock_cfn_delete):
+        fab_tasks.cfn_delete()
+        mock_cfn_delete.assert_called_once_with(pre_delete_callbacks=[fab_tasks.delete_tar])
+
+    @patch('bootstrap_salt.fab_tasks.bcfn_delete')
+    def test_cfn_delete_wrapper_with_task(self, mock_cfn_delete):
+        x = lambda x: x
+        fab_tasks.cfn_delete(pre_delete_callbacks=[x])
+        mock_cfn_delete.assert_called_once_with(pre_delete_callbacks=[x, fab_tasks.delete_tar])


### PR DESCRIPTION
Needs bootstrap-cfn 0.5.7 to be released

Since the salt.tar.gpg file is managed by this repo we think it is safe to
remove it when we are deelting the Cloudformation Stack (without which the
delete operation would fail beacuase the bucket is not empty) This is a hook
that happens automatically in the cfn_delete fab task so the user just needs to
think 'I want to delete this stack' and not have to worry what steps need to be
taken to make that happen.

It treats the tar file not existing as a warning, rather than an error as we
are deleting anyway, so it's not problem if we can't delete a non-existant
file. Ideally here a problem deleting would be different from the file not
existing but that's not possible right now.