### PR TITLE
When building the tar for upload resolve symlinks, don't copy them

### DIFF
--- a/bootstrap_salt/contrib/etc/salt/minion
+++ b/bootstrap_salt/contrib/etc/salt/minion
@@ -1,1 +1,5 @@
 file_client: local
+file_roots:
+  base:
+    - /srv/salt
+    - /srv/salt-formulas


### PR DESCRIPTION
Using `cp` was causing us problems when we run the task on linux where
it's `cp` behaves differently to OSX when it encounters symlinks. OSX
was copying the symlink contents, linux was copying the symlink itself.

Rather than having to detect the OS and invoke cp differently ourselves
the shutils module in the python standard library has a copytree
function that has a `symlink` arg that when set to False gives us the
behaviour we want: to copy the symlink as if it was a normal directory,
rather than copy the symlink as a symlink.

This means that the tar file we generate contains just the formula
folders directly in /srv/salt-formulas, so we also specify the file_root
config for salt minion so that the directory overlaying works properly
rather than mashing thing from the formulas on top of the local salt/
tree (which would reverse the precedence so that files from the formulas
would be used over files in salt/)