### PR TITLE
Fix error in creating salt tar when you project has a file in ./salt/_grains/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 1.1.x
+
+* Fix bug in `upload_salt` fab task that where you would get an OSError if you
+  had created any files in your projects ./salt/_grain folder.
+
 ## Version 1.1.1
 
 * Change how we produce the "salt.tar" so that it is both simpler and platform

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -4,7 +4,6 @@ from functools import wraps
 import math
 import os
 from pipes import quote
-import shutil
 import StringIO
 import sys
 import yaml
@@ -308,7 +307,7 @@ def upload_salt():
         # it is contained
         stage_path = os.path.join(tmp_folder, "." + dest_dir)
 
-        shutil.copytree(local_dir, stage_path, symlinks=False)
+        utils.copytree(local_dir, stage_path, symlinks=False)
 
     cfg_path = os.path.join(tmp_folder, "./{0}".format(remote_pillar_dir))
     with open(os.path.join(cfg_path, 'cloudformation.sls'), 'w') as cfg_file:

--- a/bootstrap_salt/fab_tasks.py
+++ b/bootstrap_salt/fab_tasks.py
@@ -12,6 +12,7 @@ import logging
 import pkgutil
 import gnupg
 import base64
+import shutil
 logging.basicConfig(level=logging.INFO)
 
 import bootstrap_cfn.config as config

--- a/scripts/bootstrap-salt.sh
+++ b/scripts/bootstrap-salt.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -xe
+
+# SETUP EC2 INSTANCE
+T1=`dpkg -l | grep python-setuptools | wc -l`
+T2="1"
+if [ "$T1" = "$T2" ]; then
+  echo "[INFO] Base packages already installed..."
+else
+  apt-get update
+  apt-get -y install python-setuptools git
+  easy_install boto
+fi
+
+# get bootstrap-salt, doesn't do upgrade anymore
+if [ -d "/usr/local/bootstrap-salt" ]; then
+  echo "[INFO] boostrap-salt already installed..."
+else
+  cd /usr/local && git clone https://github.com/ministryofjustice/bootstrap-salt
+  easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
+  chmod 755 /usr/local/bootstrap-salt/scripts/ec2_tags.py
+  chmod 750 /usr/local/bootstrap-salt/bootstrap_salt/salt_utils.py
+  /usr/local/bootstrap-salt/scripts/ec2_tags.py
+fi

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+import tempfile
+import unittest
+
+from bootstrap_salt import utils
+
+
+class TestUtils(unittest.TestCase):
+
+    def _create_src_folder_for_copytree(self, thedir):
+        # Creates these files and dirs in thedir:
+        #
+        # folder1/
+        # folder1/file1
+        # folder1/folder2/
+        # folder1/folder2/file2
+        #
+        # If we copy folder1/folder2 then folder1/ it should work.
+        os.makedirs(os.path.join(thedir, "folder1", "folder2"))
+        open(os.path.join(thedir, "folder1", "file1"), "w").close()
+        open(os.path.join(thedir, "folder1", "folder2", "file2"), "w").close()
+
+    def test_copytree_when_dest_already_exists(self):
+        # This tests our cutsomiztion to copytree that doesn't die if the
+        # target directory already eixts. Using shutil.copytree this would
+        # raise an OSError
+
+        tmp_src_folder = tempfile.mkdtemp()
+        tmp_dst_folder = tempfile.mkdtemp()
+        try:
+            self._create_src_folder_for_copytree(tmp_src_folder)
+
+            src1 = os.path.join(tmp_src_folder, "folder1")
+            src2 = os.path.join(tmp_src_folder, "folder1", "folder2")
+            dst1 = os.path.join(tmp_dst_folder, "folder1")
+            dst2 = os.path.join(tmp_dst_folder, "folder1", "folder2")
+
+            utils.copytree(src2, dst2)
+            utils.copytree(src1, dst1)
+        finally:
+            shutil.rmtree(tmp_src_folder, ignore_errors=True)
+            shutil.rmtree(tmp_dst_folder, ignore_errors=True)


### PR DESCRIPTION
The problem was the shutil.copytree expects the target directory to not
exists, and if it already exists then will raise an OSError. This could
happen because we first copy the project's ./salt dir to the tmp dir
(which in this case had a ./salt/_grains/neighbours.py), and then we try
to copy the contrib/srv/salt/_grains/ dir which fails because the
previous step created that folder already.

The best solution I can found (as mentioned in
http://stackoverflow.com/a/12687372/439189) is to copy the
implementation of copytree from the shutil module and put a guard around
the the makedir