### PR TITLE
In tags_to_grains don't *require* a 'aws:cloudformation:stack-name' tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Let tags_to_grains script cope when not running on an instance created
+  outside cloudformation
+
 ## Version 1.1.2
 
 * Fix bug in `upload_salt` fab task that where you would get an OSError if you


### PR DESCRIPTION
I would like to use the jenkins EC2 plugin to create slaves on demand
and have salt configure most things on there. The easiest way to get
this to work is to re-use the existing scripts, user data et al. on that
host.

Most of the time we will have one, but tags prefixed with 'aws:' can't
be set manually so if we can't set this then we just don't return ant
cloudformation outputs. This means we could use this script for manually
created EC2 instances too.