### PR TITLE
Fix log path in salt_utils script

### DIFF
--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
                         help='Name of state or "highstate"', required=True)
 
     setup_console_logger(log_level='info')
-    setup_logfile_logger(log_path='file:///var/log/salt/minion', log_level='debug')
+    setup_logfile_logger(log_path='/var/log/salt/minion', log_level='debug')
 
     args = parser.parse_args()
     if args.state == "highstate":


### PR DESCRIPTION
This was a subtle one. If you pass file:///path/to/some/file. Salt
passes this into python's logging.handlers.SysLogHandler which will try
and connect to a Unix socket at this path. If you omit the file:// then
salt creates a regular log file at the path which is what we want.
Because the file we passed wasn't a socket we couldn't connect and this
actually causes an exception to be raised.

Nearly forgot to open this! @mattpep @pwyborn 