### PR TITLE
Sync salt files before run

### DIFF
--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -62,6 +62,9 @@ def highstate():
     '''
     get_salt_data()
     caller = salt.client.Caller()
+    # synchronizes custom modules, states, beacons, grains, returners,
+    # output modules, renderers, and utils.
+    caller.function('saltutil.sync_all')
     res = caller.function('state.highstate')
     return check_state_result(res)
 


### PR DESCRIPTION
This change will ensure that all the custom modules and states, etc
are synchronised before attempting to highstate

(Closes ministryofjustice/template-deploy#171)