### PR TITLE
Update bootstrap wait check

### DIFF
--- a/bootstrap_salt/config.py
+++ b/bootstrap_salt/config.py
@@ -84,9 +84,9 @@ class MyConfigParser(ConfigParser):
                                   'permissions': '0600'},
                                  {'content': open(script).read(),
                                   'owner': 'root:root',
-                                  'path': '/tmp/bootstrap.sh',
+                                  'path': '{}/bootstrap.sh'.format(env.bootstrap_script_path),
                                   'permissions': '0700'}]}
-        commands = {'runcmd': ['/tmp/bootstrap.sh v{0}'.format(self.__version__)]}
+        commands = {'runcmd': ['{}/bootstrap.sh v{}'.format(env.bootstrap_script_path, self.__version__)]}
         ret.append({
             'content': yaml.dump(commands),
             'mime_type': 'text/cloud-config'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -123,11 +123,13 @@ class TestConfig(unittest.TestCase):
     def test_get_ec2_userdata(self, mock_env, mock_super):
         mock_super.return_value = []
         mock_env.kms_data_key = 'fake-key-data'
+        mock_env.bootstrap_script_path = '/usr/local/bin'
+        mock_env.bootstrap_tmp_path = '/tmp'
         version = pkg_resources.get_distribution("bootstrap_salt").version
 
-        expected = [{'content': 'runcmd: [/tmp/bootstrap.sh v{0}]\n'.format(version),
+        expected = [{'content': 'runcmd: [/usr/local/bin/bootstrap.sh v{0}]\n'.format(version),
                      'mime_type': 'text/cloud-config'},
-                    {'content': "write_files:\n- {content: fake-key-data, encoding: b64, owner: 'root:root', path: /etc/salt.key.enc,\n  permissions: '0600'}\n- {content: '#!/bin/bash\n\n    REVISION=$1\n\n    wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/6080a18e6c7c2d49335978fa69fa63645b45bc2a/bootstrap-salt.sh\n    -O /tmp/bootstrap-salt.sh\n\n    chmod 700 /tmp/bootstrap-salt.sh\n\n    apt-get update && apt-get -y install python-pip git python-dev\n\n    pip install boto\n\n    pip install gnupg\n\n    cd /tmp\n\n    git clone --depth 1 --branch $REVISION https://github.com/ministryofjustice/bootstrap-salt.git\n\n    cd ./bootstrap-salt/bootstrap_salt\n\n    cp -Lrf ./contrib/* /\n\n    /tmp/bootstrap-salt.sh git v2014.7.5\n\n    salt-call saltutil.sync_all\n\n    /usr/local/bin/salt_utils.py -s highstate\n\n    touch /tmp/bootstrap_done\n\n    ', owner: 'root:root', path: /tmp/bootstrap.sh, permissions: '0700'}\n", 'mime_type': 'text/cloud-config'}]  # NOQA
+                    {'content': "write_files:\n- {content: fake-key-data, encoding: b64, owner: 'root:root', path: /etc/salt.key.enc,\n  permissions: '0600'}\n- {content: '#!/bin/bash\n\n    REVISION=$1\n\n    wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/6080a18e6c7c2d49335978fa69fa63645b45bc2a/bootstrap-salt.sh\n    -O /tmp/bootstrap-salt.sh\n\n    chmod 700 /tmp/bootstrap-salt.sh\n\n    apt-get update && apt-get -y install python-pip git python-dev\n\n    pip install boto\n\n    pip install gnupg\n\n    cd /tmp\n\n    git clone --depth 1 --branch $REVISION https://github.com/ministryofjustice/bootstrap-salt.git\n\n    cd ./bootstrap-salt/bootstrap_salt\n\n    cp -Lrf ./contrib/* /\n\n    /tmp/bootstrap-salt.sh git v2014.7.5\n\n    salt-call saltutil.sync_all\n\n    /usr/local/bin/salt_utils.py -s highstate\n\n    touch /tmp/bootstrap_done\n\n    ', owner: 'root:root', path: /usr/local/bin/bootstrap.sh, permissions: '0700'}\n", 'mime_type': 'text/cloud-config'}]  # NOQA
 
         x = MyConfigParser({}, 'my-stack').get_ec2_userdata()
         compare(x, expected)


### PR DESCRIPTION
Update bootstrap wait check

While waiting for bootstraping saltstack to finish we first wait on
ssh access, then wait for the creation of the bootstrap_done file.
This procedure will break if we lose ssh access after creation of the
ec2 instances, which can happen when we reboot after security updates
during cloud-init.

This change will attempt to handle possibly losing ssh access and
recovering while waiting for saltstack bootstrapping to complete.

* Set bootstrap done file location globally as env
* Add logging
* Attempt to recover on waiting for bootstrap completion when we lose
ssh connection