### PR TITLE
Refactor salt_utils to synchronise remote data more reliably

### DIFF
--- a/bootstrap_salt/contrib/usr/local/bin/salt_utils_state.py
+++ b/bootstrap_salt/contrib/usr/local/bin/salt_utils_state.py
@@ -1,0 +1,1 @@
+../../../../salt_utils_state.py

--- a/bootstrap_salt/contrib/usr/local/bin/salt_utils_update.py
+++ b/bootstrap_salt/contrib/usr/local/bin/salt_utils_update.py
@@ -1,0 +1,1 @@
+../../../../salt_utils_update.py

--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -1,123 +1,31 @@
 #!/usr/bin/env python
-import base64
-import os
+import argparse
 import subprocess
-import sys
-
-import salt
-import salt.client
-import salt.config
-import salt.output
-import salt.runner
-
-
-class BootstrapUtilError(Exception):
-
-    def __init__(self, msg):
-        print >> sys.stderr, "[ERROR] {0}: {1}".format(self.__class__.__name__, msg)
-
-
-class SaltStateError(BootstrapUtilError):
-    pass
-
-
-class SaltParserError(BootstrapUtilError):
-    pass
-
-
-def get_salt_data():
-    import boto.s3
-    import boto.kms
-    import gnupg
-    import shutil
-
-    caller = salt.client.Caller()
-    stack_name = caller.function('grains.item', 'aws:cloudformation:stack-name')['aws:cloudformation:stack-name']
-    region = caller.function('grains.item', 'aws_region')['aws_region']
-    kms = boto.kms.connect_to_region(region)
-    s3 = boto.s3.connect_to_region(region)
-    tar_file = s3.get_bucket('{0}-salt'.format(stack_name)).get_key('srv.tar.gpg')
-    if tar_file:
-        tar_file.get_contents_to_filename('/srv.tar.gpg')
-        os.chmod('/srv.tar.gpg', 0700)
-        key = kms.decrypt(open('/etc/salt.key.enc').read())['Plaintext']
-        key = base64.b64encode(key)
-        gpg = gnupg.GPG()
-        gpg.decrypt_file(open('/srv.tar.gpg'), passphrase=key,
-                         output='/srv.tar')
-        os.chmod('/srv.tar', 0700)
-    if not tar_file and not os.path.isfile('/srv.tar'):
-        print "Salt tar not found, probably this is an initial bootstrap"
-        sys.exit(0)
-    shutil.rmtree('/srv/salt', ignore_errors=True)
-    shutil.rmtree('/srv/pillar', ignore_errors=True)
-    subprocess.call(['tar', '--no-same-owner', '-xvf', '/srv.tar', '-C', '/'])
-
-
-def highstate():
-    '''
-    Raises:
-        SaltParserError: if any minion cannot execute the state
-        SaltStateError: if any state execution returns False
-    '''
-    get_salt_data()
-    caller = salt.client.Caller()
-    # synchronizes custom modules, states, beacons, grains, returners,
-    # output modules, renderers, and utils.
-    caller.function('saltutil.sync_all')
-    res = caller.function('state.highstate')
-    return check_state_result(res)
-
-
-def state(state):
-    '''
-    Raises:
-        SaltParserError: if any minion cannot execute the state
-        SaltStateError: if any state execution returns False
-    Args:
-        state(string): the state to run
-    '''
-    get_salt_data()
-    caller = salt.client.Caller()
-    res = caller.function('state.sls', state)
-    return check_state_result(res)
-
-
-def check_state_result(result):
-    '''
-    Takes a salt results dictionary, prints the ouptut in salts highstate ouput
-    format and checks all states executed successfully. Returns True or raises:
-    Raises:
-        SaltParserError: if any minion cannot execute the state
-        SaltStateError: if any state execution returns False
-    Args:
-        result(dict): salt results dictionary
-    '''
-    __opts__ = salt.config.minion_config('/etc/salt/minion')
-    salt.output.display_output({'local': result}, out='highstate', opts=__opts__)
-    if isinstance(result, dict):
-        results = [v['result'] for v in result.values()]
-    else:
-        raise SaltParserError('Minion could not parse state data')
-    if all(results):
-        return True
-    else:
-        raise SaltStateError('State did not execute successfully')
 
 if __name__ == "__main__":
-    import argparse
-
-    from salt.log.setup import setup_console_logger, setup_logfile_logger
-
-    parser = argparse.ArgumentParser(description='Run salt states')
-    parser.add_argument('-s', dest='state', type=str,
-                        help='Name of state or "highstate"', required=True)
-
-    setup_console_logger(log_level='info')
-    setup_logfile_logger(log_path='/var/log/salt/minion', log_level='debug')
-
+    parser = argparse.ArgumentParser(
+        description=('Update the salt config '
+                     'from a remote s3 store and run a salt state')
+    )
+    parser.add_argument('-s',
+                        dest='state',
+                        type=str,
+                        help='Name of state or highstate',
+                        required=True)
+    parser.add_argument('--loglevel',
+                        dest='loglevel',
+                        type=str,
+                        help=('Level of logging detail, '
+                              'debug, info, warning, error or critical'),
+                        default="info")
     args = parser.parse_args()
-    if args.state == "highstate":
-        highstate()
-    else:
-        state(args.state)
+    # Sync the salt data from an the s3 store and synchronise
+    subprocess.call(["salt_utils_update.py",
+                     "--loglevel",
+                     args.loglevel])
+    # Run the state
+    subprocess.call(["salt_utils_state.py",
+                     "-s",
+                     args.state,
+                     "--loglevel",
+                     args.loglevel])

--- a/bootstrap_salt/salt_utils.py
+++ b/bootstrap_salt/salt_utils.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 import argparse
+import logging
+import sys
 import subprocess
+
+# Set up the logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("bootstrap-salt::salt_utils")
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -10,8 +18,25 @@ if __name__ == "__main__":
     parser.add_argument('-s',
                         dest='state',
                         type=str,
-                        help='Name of state or highstate',
-                        required=True)
+                        help='Name of state or highstate'
+                        )
+    parser.add_argument('--disable-update',
+                        dest='disable_update',
+                        help=('Disable the updating of salt config data '
+                              'from the remote repository.'),
+                        action='store_true'
+                        )
+    parser.add_argument('--ignore-errors',
+                        dest='ignore_errors',
+                        help=('Ignore problems and continue execution.'),
+                        action='store_true'
+                        )
+    parser.add_argument('--update-only',
+                        dest='update_only',
+                        help=('Do not run a state, only update the config '
+                              'data from the remote.'),
+                        action='store_true'
+                        )
     parser.add_argument('--loglevel',
                         dest='loglevel',
                         type=str,
@@ -19,13 +44,50 @@ if __name__ == "__main__":
                               'debug, info, warning, error or critical'),
                         default="info")
     args = parser.parse_args()
-    # Sync the salt data from an the s3 store and synchronise
-    subprocess.call(["salt_utils_update.py",
-                     "--loglevel",
-                     args.loglevel])
-    # Run the state
-    subprocess.call(["salt_utils_state.py",
-                     "-s",
-                     args.state,
-                     "--loglevel",
-                     args.loglevel])
+    logger.debug("Running with arg {}"
+                 .format(args))
+    # Catch inconsistent arg combinations
+    if args.state is None and not args.update_only:
+        logger.critical("Theres not state argument and update_only is not set, "
+                        "please specify a state to run or only to update the data"
+                        "... aborting")
+        sys.exit(1)
+    if args.state and args.update_only:
+        logger.critical("The state and update_only arguments are mutually "
+                        "exclusive, please choose only one at a time... aborting")
+        sys.exit(1)
+    if not args.update_only and args.state is None:
+        logger.critical("The state argument is required unless the update_only "
+                        " argument is set... aborting")
+        sys.exit(1)
+
+    if not args.disable_update:
+        # Sync the salt data from an the s3 store and synchronise
+        return_code = subprocess.call(["salt_utils_update.py",
+                                       "--loglevel",
+                                       args.loglevel])
+        if return_code != 0:
+            if not args.ignore_errors:
+                logger.critical("There was a problem updating the "
+                                "remote salt data...aborting.")
+                sys.exit(return_code)
+            else:
+                logger.critical("There was a problem updating the remote salt data, "
+                                "ignore errors set so continuing execution.")
+
+    if not args.update_only:
+        # Run the state
+        return_code = subprocess.call(["salt_utils_state.py",
+                                       "-s",
+                                       args.state,
+                                       "--loglevel",
+                                       args.loglevel])
+        if return_code != 0:
+            if not args.ignore_errors:
+                logger.critical("There was a problem running the "
+                                "salt state...aborting.")
+                sys.exit(return_code)
+            else:
+                logger.critical("There was a problem running the salt state,"
+                                "ignore errors set so continuing execution.")
+    sys.exit(0)

--- a/bootstrap_salt/salt_utils_state.py
+++ b/bootstrap_salt/salt_utils_state.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+import argparse
+from salt.log.setup import setup_console_logger, setup_logfile_logger
+
+import logging
+import sys
+
+import salt
+import salt.client
+import salt.config
+import salt.output
+
+# Set up the logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("bootstrap-salt::salt_utils")
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger('boto').setLevel(logging.CRITICAL)
+
+
+class BootstrapUtilError(Exception):
+    def __init__(self, msg):
+        super(BootstrapUtilError, self).__init__(msg)
+        print >> (sys.stderr,
+                  "[ERROR] {0}: {1}"
+                  .format(self.__class__.__name__, msg))
+
+
+class SaltStateError(BootstrapUtilError):
+    pass
+
+
+class SaltParserError(BootstrapUtilError):
+    pass
+
+
+class SaltUtilStateWrapper():
+    """
+    Class to wrap the saltutil state caller. It provides some logging
+    and error parsing.
+    """
+    caller = None
+
+    def __init__(self):
+        self.caller = salt.client.Caller()
+
+    def highstate(self):
+        """
+        Highstate the instance with data from the remote s3 bucket
+        """
+        self.state("highstate")
+
+    def state(self, state):
+        """
+        Run a salt state with data from the remote s3 bucket
+
+        Args:
+            state(string): the state to run
+        Raises:
+            SaltParserError: if any minion cannot execute the state
+            SaltStateError: if any state execution returns False
+        """
+        logger.info("state: Running state '{}'...".format(state))
+
+        # Highstate has its own state call
+        if state == 'highstate':
+            result = self.caller.function('state.highstate')
+        else:
+            result = self.caller.function('state.highstate')(state)
+
+        logger.debug("state: State results: {}".format(result))
+        return self.check_state_result(result)
+
+    def check_state_result(self, result):
+        """
+        Takes a salt results dictionary, prints the output
+        in salts highstate output format and checks all states
+        executed successfully. Returns True on success.
+
+        Args:
+            result(dict): salt results dictionary
+
+        Raises:
+            SaltParserError: if any minion cannot execute the state
+            SaltStateError: if any state execution returns False
+        """
+        __opts__ = salt.config.minion_config('/etc/salt/minion')
+        salt.output.display_output({'local': result},
+                                   out='highstate',
+                                   opts=__opts__)
+        if isinstance(result, dict):
+            # This uses a syntax parsing check to verify true results
+            results = [v['result'] for v in result.values()]
+            if all(results):
+                logging.info("check_state_result: All states successful")
+                return True
+            else:
+                raise SaltStateError('State did not execute successfully')
+        elif isinstance(result, list):
+                for entry in result:
+                    if "failed" in entry:
+                        logging.critical("check_state_result: "
+                                         "State failed, '{}'"
+                                         .format(entry))
+                        raise SaltStateError(
+                            'State did not execute successfully'
+                        )
+                return True
+        else:
+            raise SaltParserError('Minion could not parse state data')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run salt states')
+    parser.add_argument('-s',
+                        dest='state',
+                        type=str,
+                        help='Name of state or highstate',
+                        required=True)
+    parser.add_argument('--loglevel',
+                        dest='loglevel',
+                        type=str,
+                        help=("Level of logging detail, "
+                              "debug, info, warning, error or critical"),
+                        default="info")
+    args = parser.parse_args()
+    setup_console_logger(log_level=args.loglevel)
+    setup_logfile_logger(log_path='/var/log/salt/minion',
+                         log_level=args.loglevel)
+
+    salt_util_state_wrapper = SaltUtilStateWrapper()
+    salt_util_state_wrapper.state(args.state)

--- a/bootstrap_salt/salt_utils_state.py
+++ b/bootstrap_salt/salt_utils_state.py
@@ -11,8 +11,8 @@ import salt.config
 import salt.output
 
 # Set up the logging
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger("bootstrap-salt::salt_utils")
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("bootstrap-salt::salt_utils_state")
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger('boto').setLevel(logging.CRITICAL)
 

--- a/bootstrap_salt/salt_utils_state.py
+++ b/bootstrap_salt/salt_utils_state.py
@@ -61,7 +61,7 @@ class SaltUtilsStateWrapper():
         if state == 'highstate':
             result = self.caller.function('state.highstate')
         else:
-            result = self.caller.function('state.highstate')(state)
+            result = self.caller.function('state.sls', state)
         logger.debug("state: State results: {}".format(result))
         return self.check_state_result(result)
 

--- a/bootstrap_salt/salt_utils_state.py
+++ b/bootstrap_salt/salt_utils_state.py
@@ -20,10 +20,6 @@ logging.getLogger('boto').setLevel(logging.CRITICAL)
 class BootstrapUtilError(Exception):
     def __init__(self, msg):
         super(BootstrapUtilError, self).__init__(msg)
-        print >> (sys.stderr,
-                  "[ERROR] {0}: {1}"
-                  .format(self.__class__.__name__, msg))
-
 
 class SaltStateError(BootstrapUtilError):
     pass
@@ -33,7 +29,7 @@ class SaltParserError(BootstrapUtilError):
     pass
 
 
-class SaltUtilStateWrapper():
+class SaltUtilsStateWrapper():
     """
     Class to wrap the saltutil state caller. It provides some logging
     and error parsing.

--- a/bootstrap_salt/salt_utils_state.py
+++ b/bootstrap_salt/salt_utils_state.py
@@ -62,7 +62,6 @@ class SaltUtilsStateWrapper():
             result = self.caller.function('state.highstate')
         else:
             result = self.caller.function('state.highstate')(state)
-
         logger.debug("state: State results: {}".format(result))
         return self.check_state_result(result)
 
@@ -93,7 +92,7 @@ class SaltUtilsStateWrapper():
                 raise SaltStateError('State did not execute successfully')
         elif isinstance(result, list):
                 for entry in result:
-                    if "failed" in entry:
+                    if "failed" in entry.lower() or "error" in entry.lower():
                         logging.critical("check_state_result: "
                                          "State failed, '{}'"
                                          .format(entry))

--- a/bootstrap_salt/salt_utils_state.py
+++ b/bootstrap_salt/salt_utils_state.py
@@ -122,5 +122,5 @@ if __name__ == "__main__":
     setup_logfile_logger(log_path='/var/log/salt/minion',
                          log_level=args.loglevel)
 
-    salt_util_state_wrapper = SaltUtilStateWrapper()
-    salt_util_state_wrapper.state(args.state)
+    salt_utils_state_wrapper = SaltUtilsStateWrapper()
+    salt_utils_state_wrapper.state(args.state)

--- a/bootstrap_salt/salt_utils_update.py
+++ b/bootstrap_salt/salt_utils_update.py
@@ -18,8 +18,8 @@ import salt.config
 import tarfile
 
 # Set up the logging
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger("bootstrap-salt::salt_utils")
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("bootstrap-salt::salt_utils_update")
 logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger('boto').setLevel(logging.CRITICAL)
 
@@ -150,7 +150,7 @@ if __name__ == "__main__":
                         dest='loglevel',
                         type=str,
                         help='Level of logging detail',
-                        default="debug")
+                        default="info")
     args = parser.parse_args()
     setup_console_logger(log_level=args.loglevel)
     setup_logfile_logger(log_path='/var/log/salt/minion',

--- a/bootstrap_salt/salt_utils_update.py
+++ b/bootstrap_salt/salt_utils_update.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+import argparse
+from salt.log.setup import setup_console_logger, setup_logfile_logger
+
+import boto.s3
+import boto.kms
+import gnupg
+import shutil
+
+import base64
+import logging
+import os
+import sys
+
+import salt
+import salt.client
+import salt.config
+import tarfile
+
+# Set up the logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("bootstrap-salt::salt_utils")
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.getLogger('boto').setLevel(logging.CRITICAL)
+
+
+class SaltUtilUpdateWrapper():
+    """
+    Class to wrap the s3 downloading and data synchronising of salt
+    data.
+    """
+    caller = None
+
+    def __init__(self):
+        self.caller = salt.client.Caller()
+
+    def get_salt_data(self):
+        """
+        Download the salt configuration and support files from an S3
+        bucket and extract them to the correct folder.
+        """
+        logger.info("get_salt_data: Getting remote salt data...")
+
+        # Set up the connection to AWS
+        logger.info("get_salt_data: Setting up AWS connection...")
+        stack_name_grain = self.caller.function(
+            'grains.item',
+            'aws:cloudformation:stack-name'
+        )
+        stack_name = stack_name_grain[
+            'aws:cloudformation:stack-name'
+        ]
+        region = self.caller.function('grains.item',
+                                      'aws_region')['aws_region']
+        kms = boto.kms.connect_to_region(region)
+        s3 = boto.s3.connect_to_region(region)
+
+        # If the s3 stored tar file exists, download it and decrypt
+        bucket_name = '{0}-salt'.format(stack_name)
+        logger.info("get_salt_data: Getting salt data from s3 bucket: {}"
+                    .format(bucket_name))
+        tar_file = s3.get_bucket(bucket_name).get_key('srv.tar.gpg')
+        if tar_file:
+            logger.info("get_salt_data: Found tar file: {}"
+                        .format(tar_file))
+            tar_file.get_contents_to_filename('/srv.tar.gpg')
+            os.chmod('/srv.tar.gpg', 0700)
+            key = kms.decrypt(open('/etc/salt.key.enc').read())['Plaintext']
+            key = base64.b64encode(key)
+            gpg = gnupg.GPG()
+            gpg.decrypt_file(open('/srv.tar.gpg'), passphrase=key,
+                             output='/srv.tar')
+            os.chmod('/srv.tar', 0700)
+        # If this stack has not been highstated yet, no tar file will
+        # be available
+        if not tar_file and not os.path.isfile('/srv.tar'):
+            logger.warning("get_salt_data: Salt tar not found, "
+                           "probably this is an initial bootstrap")
+            sys.exit(0)
+
+        # Delete the previous configuration files and extract the new
+        logger.info("get_salt_data: Deleting previous salt config...")
+        shutil.rmtree('/srv/salt', ignore_errors=True)
+        shutil.rmtree('/srv/pillar', ignore_errors=True)
+        logger.info("get_salt_data: Extracting tar file...".format(tar_file))
+        self.untar(filename='/srv.tar', path='/')
+        logger.info("get_salt_data: Extracted tar file...".format(tar_file))
+
+    def untar(self, filename, path='/'):
+        """
+        Untar a tar file into the specified path
+
+        Args:
+            filename(string): The name of the tar file
+            path(string): The path to extract into
+        """
+        logger.info("untar: Untarring file '{}' to path '{}'..."
+                    .format(filename, path))
+        with tarfile.open(filename, "r") as tar:
+            for tarinfo in tar:
+                logger.info('untar: Extracting {}'.format(tarinfo.name))
+                tarinfo.uid = tarinfo.gid = 0
+                tarinfo.uname = tarinfo.gname = "root"
+            tar.extractall(path=path)
+        logger.info("untar: Tar file extracted")
+
+    def sync_remote_salt_data(self, clear_cache=True):
+        """
+        Synchronise the remote salt data.
+        """
+        logger.info("sync_remote_salt_data: Synchronising remote data...")
+
+        # Fetch the remote salt data
+        self.get_salt_data()
+
+        if clear_cache:
+            # Clear minions cache for new data
+            cache_clear_result = self.caller.function('saltutil.clear_cache')
+            logger.info("sync_remote_salt_data: Cleared minion cache: {}"
+                        .format(cache_clear_result))
+        # synchronizes custom modules, states, beacons, grains, returners,
+        # output modules, renderers, and utils.
+        sync_result = self.caller.function('saltutil.sync_all', 'refresh=True')
+        logger.info("sync_remote_salt_data: "
+                    "Synchronised dynamic module data: {}"
+                    .format(sync_result))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Run salt states')
+    parser.add_argument('--loglevel',
+                        dest='loglevel',
+                        type=str,
+                        help='Level of logging detail',
+                        default="debug")
+    args = parser.parse_args()
+    setup_console_logger(log_level=args.loglevel)
+    setup_logfile_logger(log_path='/var/log/salt/minion',
+                         log_level=args.loglevel)
+
+    salt_util_update_wrapper = SaltUtilUpdateWrapper()
+    salt_util_update_wrapper.sync_remote_salt_data()

--- a/bootstrap_salt/salt_utils_update.py
+++ b/bootstrap_salt/salt_utils_update.py
@@ -24,7 +24,7 @@ logging.getLogger("requests").setLevel(logging.WARNING)
 logging.getLogger('boto').setLevel(logging.CRITICAL)
 
 
-class SaltUtilUpdateWrapper():
+class SaltUtilsUpdateWrapper():
     """
     Class to wrap the s3 downloading and data synchronising of salt
     data.

--- a/bootstrap_salt/salt_utils_update.py
+++ b/bootstrap_salt/salt_utils_update.py
@@ -156,5 +156,5 @@ if __name__ == "__main__":
     setup_logfile_logger(log_path='/var/log/salt/minion',
                          log_level=args.loglevel)
 
-    salt_util_update_wrapper = SaltUtilUpdateWrapper()
-    salt_util_update_wrapper.sync_remote_salt_data()
+    salt_utils_update_wrapper = SaltUtilsUpdateWrapper()
+    salt_utils_update_wrapper.sync_remote_salt_data()

--- a/scripts/bootstrap-salt.sh
+++ b/scripts/bootstrap-salt.sh
@@ -19,5 +19,7 @@ else
   easy_install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
   chmod 755 /usr/local/bootstrap-salt/scripts/ec2_tags.py
   chmod 750 /usr/local/bootstrap-salt/bootstrap_salt/salt_utils.py
+  chmod 750 /usr/local/bootstrap-salt/bootstrap_salt/salt_utils_update.py
+  chmod 750 /usr/local/bootstrap-salt/bootstrap_salt/salt_utils_state.py
   /usr/local/bootstrap-salt/scripts/ec2_tags.py
 fi

--- a/tests/test_salt_utils_state.py
+++ b/tests/test_salt_utils_state.py
@@ -1,19 +1,25 @@
 import unittest
 import mock
 import sys
+
 # This is a hack so that we don't need salt to run our tests
 sys.modules['salt'] = mock.Mock()
 sys.modules['salt.runner'] = mock.Mock()
 sys.modules['salt.config'] = mock.Mock()
 sys.modules['salt.output'] = mock.Mock()
 sys.modules['salt.client'] = mock.Mock()
+sys.modules['salt.utils'] = mock.Mock()
+sys.modules['salt.log'] = mock.Mock()
+sys.modules['salt.log.setup'] = mock.Mock()
 import salt
-from bootstrap_salt import salt_utils
+
+from bootstrap_salt.salt_utils_state import SaltUtilsStateWrapper, SaltParserError, SaltStateError
 
 
-class SaltUtilTestCase(unittest.TestCase):
+class SaltUtilsStateTestCase(unittest.TestCase):
 
     def setUp(self):
+        self.salt_utils_state = SaltUtilsStateWrapper()
         pass
 
     def test_state_result(self):
@@ -28,26 +34,25 @@ class SaltUtilTestCase(unittest.TestCase):
         mock_caller = mock.Mock(Caller=mock_client)
 
         salt.client = mock_caller
-        salt_utils.get_salt_data = mock.Mock()
-        x = salt_utils.state('12345')
+        x = self.salt_utils_state.state('12345')
         self.assertTrue(x)
 
     def test_check_state_result_good(self):
         result = {'state': {'result': True},
                   'state1': {'result': True}}
-        x = salt_utils.check_state_result(result)
+        x = self.salt_utils_state.check_state_result(result)
         self.assertTrue(x)
 
     def test_check_state_result_bad(self):
         result = {'state': {'result': False},
                   'state1': {'result': True}}
-        with self.assertRaises(salt_utils.SaltStateError):
-            salt_utils.check_state_result(result)
+        with self.assertRaises(SaltStateError):
+            self.salt_utils_state.check_state_result(result)
 
     def test_check_state_result_parse_error(self):
         result = ['SOME SALT PARSER ERROR']
-        with self.assertRaises(salt_utils.SaltParserError):
-            salt_utils.check_state_result(result)
+        with self.assertRaises(SaltParserError):
+            self.salt_utils_state.check_state_result(result)
 
     def tearDown(self):
         pass

--- a/tests/test_salt_utils_state.py
+++ b/tests/test_salt_utils_state.py
@@ -1,58 +1,175 @@
 import unittest
-import mock
-import sys
-
-# This is a hack so that we don't need salt to run our tests
-sys.modules['salt'] = mock.Mock()
-sys.modules['salt.runner'] = mock.Mock()
-sys.modules['salt.config'] = mock.Mock()
-sys.modules['salt.output'] = mock.Mock()
-sys.modules['salt.client'] = mock.Mock()
-sys.modules['salt.utils'] = mock.Mock()
-sys.modules['salt.log'] = mock.Mock()
-sys.modules['salt.log.setup'] = mock.Mock()
-import salt
-
+from mock import MagicMock, patch
+from nose.tools import raises
 from bootstrap_salt.salt_utils_state import SaltUtilsStateWrapper, SaltParserError, SaltStateError
 
 
 class SaltUtilsStateTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.salt_utils_state = SaltUtilsStateWrapper()
         pass
 
-    def test_state_result(self):
-        salt.config = mock.Mock()
-        mock_result = mock.Mock()
-        mock_config = {'function.return_value': {'state': {'result': True}}}
-        mock_result.configure_mock(**mock_config)
+    @patch('salt.client.Caller')
+    @patch('salt.config')
+    @patch('salt.output')
+    def test_state_result_good(self,
+                               mock_salt_output,
+                               mock_salt_config,
+                               mock_salt_client_caller):
+        """
+        test_state_result_good: Test calling a state and getting back a correct result
+        """
+        # Construct nested caller function
+        instance = mock_salt_client_caller.return_value
+        instance.function.return_value = MagicMock()
+        instance.function.return_value.return_value = ['This call succeeded']
 
-        mock_client = mock.Mock()
-        mock_client.return_value = mock_result
+        # Make actual call
+        salt_utils_state = SaltUtilsStateWrapper()
+        actual_result = salt_utils_state.state('12345')
 
-        mock_caller = mock.Mock(Caller=mock_client)
+        self.assertTrue(actual_result)
 
-        salt.client = mock_caller
-        x = self.salt_utils_state.state('12345')
-        self.assertTrue(x)
+    @raises(SaltStateError)
+    @patch('salt.client.Caller')
+    @patch('salt.config')
+    @patch('salt.output')
+    def test_state_result_bad(self,
+                              mock_salt_output,
+                              mock_salt_config,
+                              mock_salt_client_caller):
+        """
+        test_state_result_bad: Test calling a state and getting back a failed result
+        """
+        # Construct nested caller function
+        instance = mock_salt_client_caller.return_value
+        instance.function.return_value = MagicMock()
+        instance.function.return_value.return_value = ['This call failed']
 
-    def test_check_state_result_good(self):
+        # Make actual call
+        salt_utils_state = SaltUtilsStateWrapper()
+        salt_utils_state.state('12345')
+
+    @patch('salt.client.Caller')
+    @patch('salt.config')
+    @patch('salt.output')
+    def test_state_result_with_dictionary_good(self,
+                                               mock_salt_output,
+                                               mock_salt_config,
+                                               mock_salt_client_caller):
+        """
+        test_state_result_with_dictionary_good: Test calling a state and getting back a correct result as a dictionary
+        """
+        # Construct nested caller function
+        instance = mock_salt_client_caller.return_value
+        instance.function.return_value = MagicMock()
+        instance.function.return_value.return_value = {'state': {'result': True}}
+
+        # Make actual call
+        salt_utils_state = SaltUtilsStateWrapper()
+        actual_result = salt_utils_state.state('12345')
+        self.assertTrue(actual_result)
+
+    @raises(SaltStateError)
+    @patch('salt.client.Caller')
+    @patch('salt.config')
+    @patch('salt.output')
+    def test_state_result_with_dictionary_bad(self,
+                                              mock_salt_output,
+                                              mock_salt_config,
+                                              mock_salt_client_caller):
+        """
+        test_state_result_with_dictionary_bad: Test calling a state and getting back a failed result as a dictionary
+        """
+        # Construct nested caller function
+        # Construct nested caller function
+        instance = mock_salt_client_caller.return_value
+        instance.function.return_value = MagicMock()
+        instance.function.return_value.return_value = {'state': {'result': False}}
+
+        # Make actual call
+        salt_utils_state = SaltUtilsStateWrapper()
+        salt_utils_state.state('12345')
+
+    @patch('salt.client.Caller')
+    @patch('salt.config')
+    @patch('salt.output')
+    def test_highstate_result_good(self,
+                                   mock_salt_output,
+                                   mock_salt_config,
+                                   mock_salt_client_caller):
+        """
+        test_highstate_result_good: Test calling a highstate and getting back a correct result
+        """
+        # Construct nested caller function
+        instance = mock_salt_client_caller.return_value
+        instance.function.return_value = ['This call succeeded']
+        # Make actual call
+        salt_utils_state = SaltUtilsStateWrapper()
+        actual_result = salt_utils_state.state('highstate')
+        self.assertTrue(actual_result)
+
+    @patch('salt.client.Caller')
+    @patch('salt.config')
+    @patch('salt.output')
+    def test_check_state_result_good(self,
+                                     mock_salt_output,
+                                     mock_salt_config,
+                                     mock_salt_client_caller):
+        """
+        test_check_state_result_good: Test checking good state result
+        """
         result = {'state': {'result': True},
                   'state1': {'result': True}}
-        x = self.salt_utils_state.check_state_result(result)
-        self.assertTrue(x)
+        salt_utils_state = SaltUtilsStateWrapper()
+        result = salt_utils_state.check_state_result(result)
+        self.assertTrue(result)
 
-    def test_check_state_result_bad(self):
+    @raises(SaltStateError)
+    @patch('salt.client.Caller')
+    @patch('salt.config')
+    @patch('salt.output')
+    def test_check_state_result_dictionary_bad(self,
+                                               mock_salt_output,
+                                               mock_salt_config,
+                                               mock_salt_client_caller):
+        """
+        test_check_state_result_dictionary_bad: Test checking failed state result as dictionary
+        """
         result = {'state': {'result': False},
                   'state1': {'result': True}}
-        with self.assertRaises(SaltStateError):
-            self.salt_utils_state.check_state_result(result)
+        salt_utils_state = SaltUtilsStateWrapper()
+        salt_utils_state.check_state_result(result)
 
-    def test_check_state_result_parse_error(self):
-        result = ['SOME SALT PARSER ERROR']
-        with self.assertRaises(SaltParserError):
-            self.salt_utils_state.check_state_result(result)
+    @raises(SaltStateError)
+    @patch('salt.client.Caller')
+    @patch('salt.config')
+    @patch('salt.output')
+    def test_check_state_result_list_bad(self,
+                                         mock_salt_output,
+                                         mock_salt_config,
+                                         mock_salt_client_caller):
+        """
+        test_check_state_result_list_bad: Test bad result as list
+        """
+        result = ['SOME SALT ERROR']
+        salt_utils_state = SaltUtilsStateWrapper()
+        salt_utils_state.check_state_result(result)
+
+    @raises(SaltParserError)
+    @patch('salt.client.Caller')
+    @patch('salt.config')
+    @patch('salt.output')
+    def test_check_state_result_parse_error(self,
+                                            mock_salt_output,
+                                            mock_salt_config,
+                                            mock_salt_client_caller):
+        """
+        test_check_state_result_parse_error: Test badly formatted result
+        """
+        result = 'SOME UNEXPECTED OUTPUT FORMAT'
+        salt_utils_state = SaltUtilsStateWrapper()
+        salt_utils_state.check_state_result(result)
 
     def tearDown(self):
         pass

--- a/tests/test_salt_utils_update.py
+++ b/tests/test_salt_utils_update.py
@@ -1,42 +1,73 @@
 import unittest
-import mock
-import sys
-
-# This is a hack so that we don't need salt to run our tests
-sys.modules['salt'] = mock.Mock()
-sys.modules['salt.runner'] = mock.Mock()
-sys.modules['salt.config'] = mock.Mock()
-sys.modules['salt.output'] = mock.Mock()
-sys.modules['salt.client'] = mock.Mock()
-sys.modules['salt.utils'] = mock.Mock()
-sys.modules['salt.log'] = mock.Mock()
-sys.modules['salt.log.setup'] = mock.Mock()
-
-import salt
+from mock import call, MagicMock, patch
 from bootstrap_salt.salt_utils_update import SaltUtilsUpdateWrapper
 
 
-class SaltUtilUpdateTestCase(unittest.TestCase):
+class SaltUtilsUpdateTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.salt_utils_update = SaltUtilsUpdateWrapper()
         pass
 
-    def test_state_result(self):
-        salt.config = mock.Mock()
-        mock_result = mock.Mock()
-        mock_config = {'function.return_value': {'state': {'result': True}}}
-        mock_result.configure_mock(**mock_config)
+    @patch('salt.client.Caller')
+    @patch('bootstrap_salt.salt_utils_update.SaltUtilsUpdateWrapper.get_salt_data')
+    def test_sync_remote_salt_data(self,
+                                   mock_get_salt_data,
+                                   mock_salt_client_caller):
+        """
+        test_sync_remote_salt_data: syncing data call makes the expected calls
+        """
+        # Construct nested caller function
+        instance = mock_salt_client_caller.return_value
+        instance.function.return_value = MagicMock()
+        instance.function.return_value.side_effect = [
+            'cache_clear dict',
+            'sync data dict'
+        ]
+        # Make actual call
+        salt_utils_update = SaltUtilsUpdateWrapper()
+        salt_utils_update.sync_remote_salt_data()
+        mock_get_salt_data.assert_called_once()
 
-        mock_client = mock.Mock()
-        mock_client.return_value = mock_result
+        expected_method_calls = [
+            call.function('saltutil.clear_cache'),
+            call.function('saltutil.sync_all', 'refresh=True')
+        ]
+        self.assertEqual(instance.method_calls,
+                         expected_method_calls,
+                         "test_sync_remote_salt_data: salt caller function "
+                         "was not called with all the expected methods")
 
-        mock_caller = mock.Mock(Caller=mock_client)
+    @patch('salt.client.Caller')
+    @patch('bootstrap_salt.salt_utils_update.SaltUtilsUpdateWrapper.get_salt_data')
+    def test_sync_remote_salt_data_no_clear_cache(self,
+                                                  mock_get_salt_data,
+                                                  mock_salt_client_caller):
+        """
+        test_sync_remote_salt_data_no_clear_cache: syncing data call makes the expected calls without clearing cache
+        """
+        # Construct nested caller function
+        instance = mock_salt_client_caller.return_value
+        instance.function.return_value = MagicMock()
+        instance.function.return_value.side_effect = [
+            'cache_clear dict',
+            'sync data dict'
+        ]
+        # Make actual call
+        salt_utils_update = SaltUtilsUpdateWrapper()
+        salt_utils_update.sync_remote_salt_data(clear_cache=False)
+        mock_get_salt_data.assert_called_once()
 
-        salt.client = mock_caller
-        self.salt_utils_update.get_salt_data = mock.Mock()
-        x = False
-        self.assertTrue(x)
+        expected_method_calls = [
+            call.function('saltutil.sync_all', 'refresh=True')
+        ]
+        self.assertEqual(instance.method_calls,
+                         expected_method_calls,
+                         "test_sync_remote_salt_data: salt caller function "
+                         "was not called with all the expected methods. "
+                         "\nactual: {} \nexpected: {}"
+                         .format(instance.method_calls,
+                                 expected_method_calls)
+                         )
 
     def tearDown(self):
         pass

--- a/tests/test_salt_utils_update.py
+++ b/tests/test_salt_utils_update.py
@@ -1,0 +1,45 @@
+import unittest
+import mock
+import sys
+
+# This is a hack so that we don't need salt to run our tests
+sys.modules['salt'] = mock.Mock()
+sys.modules['salt.runner'] = mock.Mock()
+sys.modules['salt.config'] = mock.Mock()
+sys.modules['salt.output'] = mock.Mock()
+sys.modules['salt.client'] = mock.Mock()
+sys.modules['salt.utils'] = mock.Mock()
+sys.modules['salt.log'] = mock.Mock()
+sys.modules['salt.log.setup'] = mock.Mock()
+
+import salt
+from bootstrap_salt.salt_utils_update import SaltUtilsUpdateWrapper
+
+
+class SaltUtilUpdateTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.salt_utils_update = SaltUtilsUpdateWrapper()
+        pass
+
+    def test_state_result(self):
+        salt.config = mock.Mock()
+        mock_result = mock.Mock()
+        mock_config = {'function.return_value': {'state': {'result': True}}}
+        mock_result.configure_mock(**mock_config)
+
+        mock_client = mock.Mock()
+        mock_client.return_value = mock_result
+
+        mock_caller = mock.Mock(Caller=mock_client)
+
+        salt.client = mock_caller
+        self.salt_utils_update.get_salt_data = mock.Mock()
+        x = False
+        self.assertTrue(x)
+
+    def tearDown(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refactor salt_utils to synchronise remote data more reliably

The current 2014.7 version of SaltStack doesn't handle updating
or synchronising dynamic module data and then accessing it in a
consistent manner. This leads to to inconsistencies in the versions
of custom grains, states, etc, available at different points throughout
a set of salt operations loaded into memory. Note that later versions
of salt deal with this situation better with the addition of
reload_grains and similar new methods to update internal state to reflect
the updated dynamic data during the lifetime of a salt-minion.

When the salt python modules are loaded in the script, any sequential
or concurrent operations can get custom grain information in a range of
states from fully updated to all custom grain data missing. This is due
to the data being accessed in a range of different ways dependent on the
operation, from accessing the salt.loader which might hold fully updated
data, to accessing through __grains__ such as in the template parsing
and rendering of pillar data, which might not reflect any changes
since the modules were loaded. This is an understood consequence
of the way and order salt updates grains and modules, with some
mitigation in later salt versions.

Since we don't use master/minions setups, and hence are not running
salt-minion. This means that we do not have a problem with salts
expectation that grains are relatively static throughout the lifetime
of a minion, and only that they are static throughout the
lifetime of a salt call instantiation.

This change takes a simple approach to consistently downloading and
synchronising data while maintain back compatibility. The original
salt_utils script is seperated out into two distinct scripts, one to
download and synchronise salt config data, the second to apply the state.
Along with some additional caching and syncing to provide some robustness
in the active data state, his ensures that the data accessed by the salt
state called reflects that that is expected.