### PR TITLE
Fix github slug name parsing

### DIFF
--- a/bootstrap_salt/deploy_lib/github.py
+++ b/bootstrap_salt/deploy_lib/github.py
@@ -87,7 +87,7 @@ def get_paginated_content(url,
                                      .format(result.status_code,
                                              result.text))
 
-    out.extend(r.json())
+    out.extend(result.json())
 
     # Recursively append paged results to out dictionary
     if 'next' in result.links:
@@ -202,8 +202,8 @@ def check_org_membership(org_slug, user_slug):
                    forced_org_slug,
                    forced_user_slug)
            )
-    r = requests.get(url, auth=(get_github_token(), 'x-oauth-basic'))
-    if r.status_code == 204:
+    result = requests.get(url, auth=(get_github_token(), 'x-oauth-basic'))
+    if result.status_code == 204:
         return True
     else:
         return False

--- a/bootstrap_salt/deploy_lib/github.py
+++ b/bootstrap_salt/deploy_lib/github.py
@@ -71,9 +71,9 @@ def get_paginated_content(url,
     # if we have paging, update the url
     if page is not None:
         logger.warning("get_paginated_content: "
-                     "page value is deprecated, ignoring "
-                     " specified value '{}'..."
-                     .format(page))
+                       "page value is deprecated, ignoring "
+                       " specified value '{}'..."
+                       .format(page))
     if 'auth' not in kwargs:
         kwargs['auth'] = (get_github_token(), 'x-oauth-basic')
 
@@ -85,17 +85,15 @@ def get_paginated_content(url,
         raise GithubRequestException('GH API request failed with code: {}'
                                      '\n{}'
                                      .format(result.status_code,
-                                            result.text)
-                                     )
+                                             result.text))
 
     out.extend(r.json())
 
     # Recursively append paged results to out dictionary
     if 'next' in result.links:
-        out = get_paginated_content(
-                result.links['next']['url'],
-                out=out,
-                **kwargs)
+        out = get_paginated_content(result.links['next']['url'],
+                                    out=out,
+                                    **kwargs)
     return out
 
 
@@ -126,7 +124,7 @@ def get_org_members(org_slug=DEFAULT_ORG_SLUG):
     Returns:
         response(dict): Dictionary of the response from github
     """
-     # Ensure that org name is in slug format
+    # Ensure that org name is in slug format
     forced_org_slug = check_slug_format(org_slug)
 
     url = '{}orgs/{}/members'.format(forced_org_slug)
@@ -151,8 +149,9 @@ def get_org_team(team_slug, org_slug=DEFAULT_ORG_SLUG):
     teams = get_teams(forced_org_slug)
     team = filter(lambda x: x['slug'] == forced_team_slug, teams)
     if len(team) == 0:
-        raise InvalidTeamException(
-            'Team {} is not part of org {}'.format(forced_team_slug, forced_org_slug))
+        raise InvalidTeamException('Team {} is not part of org {}'
+                                   .format(forced_team_slug,
+                                           forced_org_slug))
     else:
         return team[0]
 
@@ -225,7 +224,8 @@ def get_key_fingerprint(key):
     md5hash = hashlib.md5()
     md5hash.update(key_bytes)
     fingerprint = md5hash.hexdigest()
-    fingerprint = [fingerprint[i: (i + 2)] for i in range(0, len(fingerprint), 2)]
+    fingerprint = [fingerprint[i: (i + 2)]
+                   for i in range(0, len(fingerprint), 2)]
     return ':'.join(fingerprint)
 
 
@@ -313,7 +313,7 @@ def get_keys(data):
 
 def check_slug_format(str):
     """
-    Helper function to ensure that a string is in 
+    Helper function to ensure that a string is in
     a slugged format
 
     Args:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML==3.11
 boto==2.36.0
 mock==1.0.1
 dnspython
+python-slugify

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
         'ndg-httpsclient',
         'dnspython',
         'awscli',
-        'gnupg'
+        'gnupg',
+        'python-slugify'
     ],
     setup_requires=[
         'mock>=1.0.1',

--- a/tests/github_tests.py
+++ b/tests/github_tests.py
@@ -15,8 +15,8 @@ class GithubTest(unittest.TestCase):
         github.get_paginated_content = content_mock
 
         self.orgs_document = [
-            {'slug': 'teamA', 'id': '123456'},
-            {'slug': 'teamB', 'id': '789012'},
+            {'slug': 'team-a', 'id': '123456'},
+            {'slug': 'team-b', 'id': '789012'},
         ]
 
         rsa_pub_key = '''ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEA5KtkJ1gcLKYa''' \
@@ -43,11 +43,13 @@ class GithubTest(unittest.TestCase):
         self.public_keys = {
             'rsa': {
                 'key': rsa_pub_key,
-                'fingerprint': '09:05:ee:46:39:5d:87:e2:05:42:07:0b:c7:4a:63:a9'
+                'fingerprint': ('09:05:ee:46:39:5d:87:e2'
+                                ':05:42:07:0b:c7:4a:63:a9')
             },
             'dsa': {
                 'key': dsa_pub_key,
-                'fingerprint': '35:53:6f:27:fe:39:8b:d8:dd:87:19:f3:40:d2:84:6a'
+                'fingerprint': ('35:53:6f:27:fe:39:8b:d8'
+                                ':dd:87:19:f3:40:d2:84:6a')
             },
             'invalid': {
                 'key': invalid_pub_key,
@@ -59,7 +61,10 @@ class GithubTest(unittest.TestCase):
             }
         }
 
-        self.users_document = [self.public_keys['rsa'], self.public_keys['dsa']]
+        self.users_document = [
+            self.public_keys['rsa'],
+            self.public_keys['dsa']
+        ]
 
     def handle_orgs_request(self, path):
         return self.orgs_document
@@ -67,15 +72,17 @@ class GithubTest(unittest.TestCase):
     def handle_users_request(self, path):
         if path.split('/')[-1] == 'keys':
             user = path.split('/')[2]
-            if user == 'good_user':
+            if user == 'good-user':
                 return [self.public_keys['rsa']]
-            elif user == 'bad_user':
+            elif user == 'slug-user':
+                return [self.public_keys['rsa']]
+            elif user == 'bad-user':
                 raise github.GithubRequestException
-            elif user == 'good_invalid_keys':
+            elif user == 'good-invalid-keys':
                 return [self.public_keys['invalid']]
-            elif user == 'good_no_keys':
+            elif user == 'good-no-keys':
                 return []
-            elif user == 'good_all_keys':
+            elif user == 'good-all-keys':
                 return [self.public_keys['rsa'], self.public_keys['dsa']]
 
     def content_side_effect(self, *args, **kwargs):
@@ -93,16 +100,33 @@ class GithubTest(unittest.TestCase):
         return responses_map.get(path.split('/')[1])(path)
 
     def test_get_org_team(self):
+        """
+        Test getting team in an organisation
+        """
         # test existing team
-        x = github.get_org_team('teamA')
-        self.assertEquals(x['slug'], 'teamA')
+        x = github.get_org_team('team-a')
+        self.assertEquals(x['slug'], 'team-a')
+
+        # test non existing team
+        self.assertRaises(github.InvalidTeamException,
+                          github.get_org_team, 'nonexistingteam')
+
+    def test_get_org_team_translated_to_slug(self):
+        """
+        Test getting org team with slug translation
+        """
+        # test existing team
+        x = github.get_org_team('team_A')
+        self.assertEquals(x['slug'], 'team-a')
 
         # test non existing team
         self.assertRaises(github.InvalidTeamException,
                           github.get_org_team, 'nonexistingteam')
 
     def test_get_key_fingerprint(self):
-
+        """
+        Test getting a key fingerprint
+        """
         # test rsa fingerprint
         rsa_fingerprint = github.get_key_fingerprint(self.public_keys['rsa'])
         self.assertEquals(rsa_fingerprint,
@@ -124,23 +148,25 @@ class GithubTest(unittest.TestCase):
                           self.public_keys['not_a_key'])
 
     def test_get_user_keys(self):
-
+        """
+        Test getting user keys
+        """
         # existing user with key
-        self.assertEquals(github.get_user_keys('good_user'),
+        self.assertEquals(github.get_user_keys('good-user'),
                           [self.public_keys['rsa']])
 
         # non existing user
         self.assertRaises(github.GithubRequestException, github.get_user_keys,
-                          'bad_user')
+                          'bad-user')
 
         # existing user with no keys
-        self.assertEquals([], github.get_user_keys('good_no_keys'))
+        self.assertEquals([], github.get_user_keys('good-no-keys'))
 
         # existing user with multiple keys filtered by fingerprint
         self.assertEquals(
             [self.public_keys['rsa']],
             github.get_user_keys(
-                'good_all_keys',
+                'good-all-keys',
                 fingerprints=[self.public_keys['rsa']['fingerprint']]))
 
         # existing user with single key and multiple fingerprints
@@ -148,6 +174,17 @@ class GithubTest(unittest.TestCase):
         self.assertEquals(
             [self.public_keys['rsa']],
             github.get_user_keys(
-                'good_user',
+                'good-user',
                 fingerprints=[self.public_keys['rsa']['fingerprint'],
                               self.public_keys['rsa']['fingerprint']]))
+
+    def test_get_user_keys_translated_to_slug(self):
+        """
+        Test that user names are correctly translated to slugs
+        """
+        # existing user with key
+        self.assertEquals(github.get_user_keys('Slug_user'),
+                          [self.public_keys['rsa']])
+        # existing user with key
+        self.assertEquals(github.get_user_keys('Slug User'),
+                          [self.public_keys['rsa']])


### PR DESCRIPTION
Currently the code used to talk to the gihub API uses the real
names of orgs, teams and users interchangible with the slugged versions
required to talk to the API. This change ensures that we use slugged
names consistently throughout the github utilising code.
