### PR TITLE
Fix test dependencies on salt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: python
 
 install:
-  - pip install coveralls flake8
+  - pip install coveralls flake8 salt==2014.7.5
 
 python:
   - "2.7"

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     setup_requires=[
         'mock>=1.0.1',
         'testfixtures>=4.1.2',
+        'salt==2014.7.5',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Some of the tests require on modules that in turn rely on salt.
The test requirements in setup.py don't pull in salt, so the tests
will fail. This change ensures salt 2014.7.5 is available to the
tests.